### PR TITLE
feat: add state tracking for apt-bundle managed packages

### DIFF
--- a/internal/apt/state.go
+++ b/internal/apt/state.go
@@ -1,0 +1,175 @@
+package apt
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+)
+
+const (
+	// StateDir is the directory where apt-bundle stores its state
+	StateDir = "/var/lib/apt-bundle"
+	// StateFile is the filename for the state file
+	StateFile = "state.json"
+	// StateVersion is the current version of the state file format
+	StateVersion = 1
+)
+
+// State represents the apt-bundle managed state
+type State struct {
+	Version      int      `json:"version"`
+	Packages     []string `json:"packages"`
+	Repositories []string `json:"repositories"`
+	Keys         []string `json:"keys"`
+}
+
+// statePath is the function used to get the state file path (overridable for testing)
+var statePath = func() string {
+	return filepath.Join(StateDir, StateFile)
+}
+
+// NewState creates a new empty state
+func NewState() *State {
+	return &State{
+		Version:      StateVersion,
+		Packages:     []string{},
+		Repositories: []string{},
+		Keys:         []string{},
+	}
+}
+
+// LoadState loads the state from disk, or returns a new state if none exists
+func LoadState() (*State, error) {
+	path := statePath()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return NewState(), nil
+		}
+		return nil, err
+	}
+
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+
+	return &state, nil
+}
+
+// Save persists the state to disk
+func (s *State) Save() error {
+	path := statePath()
+
+	// Ensure the directory exists
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0644)
+}
+
+// AddPackage adds a package to the state if not already present
+func (s *State) AddPackage(pkg string) bool {
+	if slices.Contains(s.Packages, pkg) {
+		return false
+	}
+	s.Packages = append(s.Packages, pkg)
+	return true
+}
+
+// RemovePackage removes a package from the state
+func (s *State) RemovePackage(pkg string) bool {
+	idx := slices.Index(s.Packages, pkg)
+	if idx == -1 {
+		return false
+	}
+	s.Packages = slices.Delete(s.Packages, idx, idx+1)
+	return true
+}
+
+// HasPackage checks if a package is tracked in the state
+func (s *State) HasPackage(pkg string) bool {
+	return slices.Contains(s.Packages, pkg)
+}
+
+// AddRepository adds a repository to the state if not already present
+func (s *State) AddRepository(repo string) bool {
+	if slices.Contains(s.Repositories, repo) {
+		return false
+	}
+	s.Repositories = append(s.Repositories, repo)
+	return true
+}
+
+// RemoveRepository removes a repository from the state
+func (s *State) RemoveRepository(repo string) bool {
+	idx := slices.Index(s.Repositories, repo)
+	if idx == -1 {
+		return false
+	}
+	s.Repositories = slices.Delete(s.Repositories, idx, idx+1)
+	return true
+}
+
+// HasRepository checks if a repository is tracked in the state
+func (s *State) HasRepository(repo string) bool {
+	return slices.Contains(s.Repositories, repo)
+}
+
+// AddKey adds a key to the state if not already present
+func (s *State) AddKey(key string) bool {
+	if slices.Contains(s.Keys, key) {
+		return false
+	}
+	s.Keys = append(s.Keys, key)
+	return true
+}
+
+// RemoveKey removes a key from the state
+func (s *State) RemoveKey(key string) bool {
+	idx := slices.Index(s.Keys, key)
+	if idx == -1 {
+		return false
+	}
+	s.Keys = slices.Delete(s.Keys, idx, idx+1)
+	return true
+}
+
+// HasKey checks if a key is tracked in the state
+func (s *State) HasKey(key string) bool {
+	return slices.Contains(s.Keys, key)
+}
+
+// GetPackagesNotIn returns packages in state that are not in the given list
+func (s *State) GetPackagesNotIn(packages []string) []string {
+	var result []string
+	for _, pkg := range s.Packages {
+		if !slices.Contains(packages, pkg) {
+			result = append(result, pkg)
+		}
+	}
+	return result
+}
+
+// SetStatePath sets the state file path (for testing only)
+func SetStatePath(path string) {
+	statePath = func() string {
+		return path
+	}
+}
+
+// ResetStatePath resets the state path to the default (for testing only)
+func ResetStatePath() {
+	statePath = func() string {
+		return filepath.Join(StateDir, StateFile)
+	}
+}

--- a/internal/apt/state_test.go
+++ b/internal/apt/state_test.go
@@ -1,0 +1,283 @@
+package apt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewState(t *testing.T) {
+	state := NewState()
+
+	if state.Version != StateVersion {
+		t.Errorf("Expected version %d, got %d", StateVersion, state.Version)
+	}
+	if len(state.Packages) != 0 {
+		t.Errorf("Expected empty packages, got %v", state.Packages)
+	}
+	if len(state.Repositories) != 0 {
+		t.Errorf("Expected empty repositories, got %v", state.Repositories)
+	}
+	if len(state.Keys) != 0 {
+		t.Errorf("Expected empty keys, got %v", state.Keys)
+	}
+}
+
+func TestStatePackages(t *testing.T) {
+	state := NewState()
+
+	t.Run("add package", func(t *testing.T) {
+		added := state.AddPackage("vim")
+		if !added {
+			t.Error("Expected package to be added")
+		}
+		if !state.HasPackage("vim") {
+			t.Error("Expected HasPackage to return true")
+		}
+	})
+
+	t.Run("add duplicate package", func(t *testing.T) {
+		added := state.AddPackage("vim")
+		if added {
+			t.Error("Expected duplicate package not to be added")
+		}
+		if len(state.Packages) != 1 {
+			t.Errorf("Expected 1 package, got %d", len(state.Packages))
+		}
+	})
+
+	t.Run("add another package", func(t *testing.T) {
+		added := state.AddPackage("curl")
+		if !added {
+			t.Error("Expected package to be added")
+		}
+		if len(state.Packages) != 2 {
+			t.Errorf("Expected 2 packages, got %d", len(state.Packages))
+		}
+	})
+
+	t.Run("remove package", func(t *testing.T) {
+		removed := state.RemovePackage("vim")
+		if !removed {
+			t.Error("Expected package to be removed")
+		}
+		if state.HasPackage("vim") {
+			t.Error("Expected HasPackage to return false")
+		}
+		if len(state.Packages) != 1 {
+			t.Errorf("Expected 1 package, got %d", len(state.Packages))
+		}
+	})
+
+	t.Run("remove nonexistent package", func(t *testing.T) {
+		removed := state.RemovePackage("nonexistent")
+		if removed {
+			t.Error("Expected remove to return false for nonexistent package")
+		}
+	})
+}
+
+func TestStateRepositories(t *testing.T) {
+	state := NewState()
+
+	t.Run("add repository", func(t *testing.T) {
+		added := state.AddRepository("docker.sources")
+		if !added {
+			t.Error("Expected repository to be added")
+		}
+		if !state.HasRepository("docker.sources") {
+			t.Error("Expected HasRepository to return true")
+		}
+	})
+
+	t.Run("add duplicate repository", func(t *testing.T) {
+		added := state.AddRepository("docker.sources")
+		if added {
+			t.Error("Expected duplicate repository not to be added")
+		}
+	})
+
+	t.Run("remove repository", func(t *testing.T) {
+		removed := state.RemoveRepository("docker.sources")
+		if !removed {
+			t.Error("Expected repository to be removed")
+		}
+		if state.HasRepository("docker.sources") {
+			t.Error("Expected HasRepository to return false")
+		}
+	})
+}
+
+func TestStateKeys(t *testing.T) {
+	state := NewState()
+
+	t.Run("add key", func(t *testing.T) {
+		added := state.AddKey("docker.gpg")
+		if !added {
+			t.Error("Expected key to be added")
+		}
+		if !state.HasKey("docker.gpg") {
+			t.Error("Expected HasKey to return true")
+		}
+	})
+
+	t.Run("add duplicate key", func(t *testing.T) {
+		added := state.AddKey("docker.gpg")
+		if added {
+			t.Error("Expected duplicate key not to be added")
+		}
+	})
+
+	t.Run("remove key", func(t *testing.T) {
+		removed := state.RemoveKey("docker.gpg")
+		if !removed {
+			t.Error("Expected key to be removed")
+		}
+		if state.HasKey("docker.gpg") {
+			t.Error("Expected HasKey to return false")
+		}
+	})
+}
+
+func TestGetPackagesNotIn(t *testing.T) {
+	state := NewState()
+	state.AddPackage("vim")
+	state.AddPackage("curl")
+	state.AddPackage("git")
+	state.AddPackage("htop")
+
+	t.Run("some packages not in list", func(t *testing.T) {
+		notIn := state.GetPackagesNotIn([]string{"vim", "git"})
+		if len(notIn) != 2 {
+			t.Errorf("Expected 2 packages not in list, got %d", len(notIn))
+		}
+		// Should contain curl and htop
+		found := make(map[string]bool)
+		for _, pkg := range notIn {
+			found[pkg] = true
+		}
+		if !found["curl"] || !found["htop"] {
+			t.Errorf("Expected curl and htop, got %v", notIn)
+		}
+	})
+
+	t.Run("all packages in list", func(t *testing.T) {
+		notIn := state.GetPackagesNotIn([]string{"vim", "curl", "git", "htop"})
+		if len(notIn) != 0 {
+			t.Errorf("Expected 0 packages not in list, got %d", len(notIn))
+		}
+	})
+
+	t.Run("no packages in list", func(t *testing.T) {
+		notIn := state.GetPackagesNotIn([]string{})
+		if len(notIn) != 4 {
+			t.Errorf("Expected 4 packages not in list, got %d", len(notIn))
+		}
+	})
+}
+
+func TestStatePersistence(t *testing.T) {
+	// Create a temp directory for testing
+	tmpDir, err := os.MkdirTemp("", "apt-bundle-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	testStatePath := filepath.Join(tmpDir, "state.json")
+	SetStatePath(testStatePath)
+	defer ResetStatePath()
+
+	t.Run("save and load state", func(t *testing.T) {
+		state := NewState()
+		state.AddPackage("vim")
+		state.AddPackage("curl")
+		state.AddRepository("docker.sources")
+		state.AddKey("docker.gpg")
+
+		err := state.Save()
+		if err != nil {
+			t.Fatalf("Failed to save state: %v", err)
+		}
+
+		// Verify file was created
+		if _, err := os.Stat(testStatePath); os.IsNotExist(err) {
+			t.Fatal("State file was not created")
+		}
+
+		// Load the state
+		loaded, err := LoadState()
+		if err != nil {
+			t.Fatalf("Failed to load state: %v", err)
+		}
+
+		// Verify loaded state matches
+		if loaded.Version != StateVersion {
+			t.Errorf("Expected version %d, got %d", StateVersion, loaded.Version)
+		}
+		if len(loaded.Packages) != 2 {
+			t.Errorf("Expected 2 packages, got %d", len(loaded.Packages))
+		}
+		if !loaded.HasPackage("vim") || !loaded.HasPackage("curl") {
+			t.Error("Expected loaded state to have vim and curl")
+		}
+		if !loaded.HasRepository("docker.sources") {
+			t.Error("Expected loaded state to have docker.sources repository")
+		}
+		if !loaded.HasKey("docker.gpg") {
+			t.Error("Expected loaded state to have docker.gpg key")
+		}
+	})
+}
+
+func TestLoadStateNonexistent(t *testing.T) {
+	// Create a temp directory for testing
+	tmpDir, err := os.MkdirTemp("", "apt-bundle-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	testStatePath := filepath.Join(tmpDir, "nonexistent", "state.json")
+	SetStatePath(testStatePath)
+	defer ResetStatePath()
+
+	state, err := LoadState()
+	if err != nil {
+		t.Fatalf("Expected no error for nonexistent state file, got %v", err)
+	}
+
+	if state.Version != StateVersion {
+		t.Errorf("Expected version %d, got %d", StateVersion, state.Version)
+	}
+	if len(state.Packages) != 0 {
+		t.Errorf("Expected empty packages, got %v", state.Packages)
+	}
+}
+
+func TestSaveCreatesDirectory(t *testing.T) {
+	// Create a temp directory for testing
+	tmpDir, err := os.MkdirTemp("", "apt-bundle-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Use a nested path that doesn't exist
+	testStatePath := filepath.Join(tmpDir, "nested", "dir", "state.json")
+	SetStatePath(testStatePath)
+	defer ResetStatePath()
+
+	state := NewState()
+	state.AddPackage("vim")
+
+	err = state.Save()
+	if err != nil {
+		t.Fatalf("Failed to save state: %v", err)
+	}
+
+	// Verify file was created
+	if _, err := os.Stat(testStatePath); os.IsNotExist(err) {
+		t.Fatal("State file was not created in nested directory")
+	}
+}

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -45,18 +45,24 @@ func runInstall(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Found %d entries in Aptfile\n", len(entries))
 
+	// Load the state to track managed packages
+	state, err := apt.LoadState()
+	if err != nil {
+		return fmt.Errorf("failed to load state: %w", err)
+	}
+
 	// TODO: Implement the actual installation logic
 	// 1. Process all 'key' directives
 	// 2. Process all 'ppa' directives
 	// 3. Process all 'deb' directives
-	
+
 	// 4. Run apt-get update (unless --no-update is specified)
 	if !noUpdate {
 		if err := apt.Update(); err != nil {
 			return fmt.Errorf("failed to update package lists: %w", err)
 		}
 	}
-	
+
 	// 5. Process all 'apt' directives to install packages
 	packagesToInstall := []string{}
 	for _, entry := range entries {
@@ -75,6 +81,9 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			}
 			if installed {
 				fmt.Printf("✓ Package %s is already installed\n", pkg)
+				// Track the package in state even if already installed
+				// (user may have installed it manually before using apt-bundle)
+				state.AddPackage(pkg)
 				continue
 			}
 
@@ -82,10 +91,18 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			if err := apt.InstallPackage(pkg); err != nil {
 				return fmt.Errorf("failed to install package %s: %w", pkg, err)
 			}
+
+			// Track successfully installed package in state
+			state.AddPackage(pkg)
 		}
 		fmt.Println("✓ All packages installed successfully")
 	} else {
 		fmt.Println("No packages to install")
+	}
+
+	// Save the updated state
+	if err := state.Save(); err != nil {
+		return fmt.Errorf("failed to save state: %w", err)
 	}
 
 	return nil

--- a/internal/commands/install_test.go
+++ b/internal/commands/install_test.go
@@ -219,12 +219,16 @@ func TestRunInstallWithMock(t *testing.T) {
 		apt.SetExecutor(mock)
 		defer apt.ResetExecutor()
 
+		// Setup state path
+		tmpDir := t.TempDir()
+		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
+		defer apt.ResetStatePath()
+
 		// Save and restore noUpdate flag
 		originalNoUpdate := noUpdate
 		defer func() { noUpdate = originalNoUpdate }()
 		noUpdate = true // Skip apt-get update
 
-		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "Aptfile")
 		content := "# Just a comment\n"
 
@@ -257,12 +261,16 @@ func TestRunInstallWithMock(t *testing.T) {
 		apt.SetExecutor(mock)
 		defer apt.ResetExecutor()
 
+		// Setup state path
+		tmpDir := t.TempDir()
+		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
+		defer apt.ResetStatePath()
+
 		// Enable update
 		originalNoUpdate := noUpdate
 		defer func() { noUpdate = originalNoUpdate }()
 		noUpdate = false
 
-		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "Aptfile")
 		content := "apt curl\napt git\n"
 
@@ -306,12 +314,16 @@ func TestRunInstallWithMock(t *testing.T) {
 		apt.SetExecutor(mock)
 		defer apt.ResetExecutor()
 
+		// Setup state path
+		tmpDir := t.TempDir()
+		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
+		defer apt.ResetStatePath()
+
 		// Disable update
 		originalNoUpdate := noUpdate
 		defer func() { noUpdate = originalNoUpdate }()
 		noUpdate = true
 
-		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "Aptfile")
 		content := "apt curl\n"
 
@@ -351,11 +363,15 @@ func TestRunInstallWithMock(t *testing.T) {
 		apt.SetExecutor(mock)
 		defer apt.ResetExecutor()
 
+		// Setup state path
+		tmpDir := t.TempDir()
+		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
+		defer apt.ResetStatePath()
+
 		originalNoUpdate := noUpdate
 		defer func() { noUpdate = originalNoUpdate }()
 		noUpdate = true
 
-		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "Aptfile")
 		content := "apt curl\n"
 
@@ -394,11 +410,15 @@ func TestRunInstallWithMock(t *testing.T) {
 		apt.SetExecutor(mock)
 		defer apt.ResetExecutor()
 
+		// Setup state path
+		tmpDir := t.TempDir()
+		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
+		defer apt.ResetStatePath()
+
 		originalNoUpdate := noUpdate
 		defer func() { noUpdate = originalNoUpdate }()
 		noUpdate = false
 
-		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "Aptfile")
 		content := "apt curl\n"
 
@@ -433,11 +453,15 @@ func TestRunInstallWithMock(t *testing.T) {
 		apt.SetExecutor(mock)
 		defer apt.ResetExecutor()
 
+		// Setup state path
+		tmpDir := t.TempDir()
+		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
+		defer apt.ResetStatePath()
+
 		originalNoUpdate := noUpdate
 		defer func() { noUpdate = originalNoUpdate }()
 		noUpdate = true
 
-		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "Aptfile")
 		content := "apt nonexistent-package\n"
 
@@ -472,11 +496,15 @@ func TestRunInstallWithMock(t *testing.T) {
 		apt.SetExecutor(mock)
 		defer apt.ResetExecutor()
 
+		// Setup state path
+		tmpDir := t.TempDir()
+		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
+		defer apt.ResetStatePath()
+
 		originalNoUpdate := noUpdate
 		defer func() { noUpdate = originalNoUpdate }()
 		noUpdate = true
 
-		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "Aptfile")
 		content := "apt curl\n"
 


### PR DESCRIPTION
Track packages, repositories, and keys installed by apt-bundle in a state file at /var/lib/apt-bundle/state.json. This enables the upcoming cleanup command to safely remove only packages that apt-bundle installed, without affecting packages from base images or manual installations.

- Add internal/apt/state.go with State struct and Load/Save operations
- Update install command to track packages in state after installation
- Add comprehensive tests for state management