### PR TITLE
feat: add cleanup command to remove unmanaged packages

### DIFF
--- a/internal/apt/packages.go
+++ b/internal/apt/packages.go
@@ -38,3 +38,66 @@ func Update() error {
 	fmt.Println("✓ Package lists updated")
 	return nil
 }
+
+// RemovePackage removes a package using apt-get
+func RemovePackage(packageName string) error {
+	fmt.Printf("Removing package: %s\n", packageName)
+
+	if err := runCommand("apt-get", "remove", "-y", packageName); err != nil {
+		return wrapCommandError(err, "remove package", packageName)
+	}
+
+	fmt.Printf("✓ Package %s removed successfully\n", packageName)
+	return nil
+}
+
+// AutoRemove removes orphaned dependencies using apt-get autoremove
+func AutoRemove() error {
+	fmt.Println("Removing orphaned dependencies...")
+
+	if err := runCommand("apt-get", "autoremove", "-y"); err != nil {
+		return wrapCommandError(err, "autoremove packages", "")
+	}
+
+	fmt.Println("✓ Orphaned dependencies removed")
+	return nil
+}
+
+// GetAllInstalledPackages returns a list of all manually installed packages
+func GetAllInstalledPackages() ([]string, error) {
+	output, err := runCommandWithOutput("apt-mark", "showmanual")
+	if err != nil {
+		return nil, wrapCommandError(err, "list installed packages", "")
+	}
+
+	// Split output by newlines and filter empty strings
+	lines := splitLines(string(output))
+	var packages []string
+	for _, line := range lines {
+		if line != "" {
+			packages = append(packages, line)
+		}
+	}
+
+	return packages, nil
+}
+
+// splitLines splits a string by newlines, handling both \n and \r\n
+func splitLines(s string) []string {
+	var lines []string
+	var current []byte
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			lines = append(lines, string(current))
+			current = current[:0]
+		} else if s[i] == '\r' {
+			// Skip \r
+		} else {
+			current = append(current, s[i])
+		}
+	}
+	if len(current) > 0 {
+		lines = append(lines, string(current))
+	}
+	return lines
+}

--- a/internal/commands/cleanup.go
+++ b/internal/commands/cleanup.go
@@ -1,0 +1,185 @@
+package commands
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/apt-bundle/apt-bundle/internal/apt"
+	"github.com/apt-bundle/apt-bundle/internal/aptfile"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cleanupForce      bool
+	cleanupZap        bool
+	cleanupAutoremove bool
+)
+
+var cleanupCmd = &cobra.Command{
+	Use:   "cleanup",
+	Short: "Remove packages not listed in Aptfile",
+	Long: `Remove packages that were previously installed by apt-bundle but are no longer
+listed in the Aptfile.
+
+By default, cleanup only removes packages that apt-bundle itself installed (tracked
+in the state file). This is safe to use with Docker base images or systems where
+you've manually installed packages.
+
+Use --zap to remove ALL packages not in the Aptfile (dangerous - may break your system).`,
+	RunE: runCleanup,
+}
+
+func init() {
+	cleanupCmd.Flags().BoolVar(&cleanupForce, "force", false, "Actually remove packages (default is dry-run)")
+	cleanupCmd.Flags().BoolVar(&cleanupZap, "zap", false, "Remove ALL packages not in Aptfile (dangerous)")
+	cleanupCmd.Flags().BoolVar(&cleanupAutoremove, "autoremove", false, "Also run apt autoremove after cleanup")
+	rootCmd.AddCommand(cleanupCmd)
+}
+
+func runCleanup(cmd *cobra.Command, args []string) error {
+	// Check for root privileges if actually removing packages
+	if cleanupForce {
+		if err := checkRoot(); err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("Reading Aptfile from: %s\n", aptfilePath)
+
+	// Parse the Aptfile
+	entries, err := aptfile.Parse(aptfilePath)
+	if err != nil {
+		return fmt.Errorf("failed to parse Aptfile: %w", err)
+	}
+
+	// Get packages from Aptfile
+	aptfilePackages := []string{}
+	for _, entry := range entries {
+		if entry.Type == "apt" {
+			aptfilePackages = append(aptfilePackages, entry.Value)
+		}
+	}
+
+	var packagesToRemove []string
+
+	if cleanupZap {
+		// Zap mode: remove ALL packages not in Aptfile
+		packagesToRemove, err = getPackagesToZap(aptfilePackages)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Normal mode: only remove packages tracked by apt-bundle
+		packagesToRemove, err = getPackagesToCleanup(aptfilePackages)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(packagesToRemove) == 0 {
+		fmt.Println("✓ Nothing to clean up")
+		return nil
+	}
+
+	// Display what will be removed
+	if cleanupZap {
+		fmt.Printf("\n⚠️  ZAP MODE: The following %d packages are NOT in your Aptfile and will be removed:\n", len(packagesToRemove))
+	} else {
+		fmt.Printf("\nThe following %d packages were installed by apt-bundle but are no longer in your Aptfile:\n", len(packagesToRemove))
+	}
+
+	for _, pkg := range packagesToRemove {
+		fmt.Printf("  - %s\n", pkg)
+	}
+	fmt.Println()
+
+	if !cleanupForce {
+		fmt.Println("Run with --force to actually remove these packages")
+		return nil
+	}
+
+	// If zap mode, require explicit confirmation
+	if cleanupZap {
+		fmt.Print("⚠️  WARNING: This will remove packages that may be critical to your system.\n")
+		fmt.Print("Type 'yes' to confirm: ")
+
+		reader := bufio.NewReader(os.Stdin)
+		confirmation, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("failed to read confirmation: %w", err)
+		}
+
+		if strings.TrimSpace(confirmation) != "yes" {
+			fmt.Println("Aborted.")
+			return nil
+		}
+	}
+
+	// Load state for updating after removal
+	state, err := apt.LoadState()
+	if err != nil {
+		return fmt.Errorf("failed to load state: %w", err)
+	}
+
+	// Remove packages
+	fmt.Printf("Removing %d packages...\n", len(packagesToRemove))
+	for _, pkg := range packagesToRemove {
+		if err := apt.RemovePackage(pkg); err != nil {
+			return fmt.Errorf("failed to remove package %s: %w", pkg, err)
+		}
+		// Update state
+		state.RemovePackage(pkg)
+	}
+
+	// Save updated state
+	if err := state.Save(); err != nil {
+		return fmt.Errorf("failed to save state: %w", err)
+	}
+
+	fmt.Printf("✓ Removed %d packages\n", len(packagesToRemove))
+
+	// Run autoremove if requested
+	if cleanupAutoremove {
+		if err := apt.AutoRemove(); err != nil {
+			return fmt.Errorf("failed to autoremove: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// getPackagesToCleanup returns packages that were installed by apt-bundle but are no longer in Aptfile
+func getPackagesToCleanup(aptfilePackages []string) ([]string, error) {
+	state, err := apt.LoadState()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load state: %w", err)
+	}
+
+	return state.GetPackagesNotIn(aptfilePackages), nil
+}
+
+// getPackagesToZap returns ALL manually installed packages that are not in Aptfile
+func getPackagesToZap(aptfilePackages []string) ([]string, error) {
+	allInstalled, err := apt.GetAllInstalledPackages()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get installed packages: %w", err)
+	}
+
+	// Build a set of aptfile packages for fast lookup
+	aptfileSet := make(map[string]bool)
+	for _, pkg := range aptfilePackages {
+		aptfileSet[pkg] = true
+	}
+
+	// Find packages not in Aptfile
+	var toRemove []string
+	for _, pkg := range allInstalled {
+		if !aptfileSet[pkg] {
+			toRemove = append(toRemove, pkg)
+		}
+	}
+
+	return toRemove, nil
+}

--- a/internal/commands/cleanup_test.go
+++ b/internal/commands/cleanup_test.go
@@ -1,0 +1,441 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/apt-bundle/apt-bundle/internal/apt"
+)
+
+func TestCleanupCmd(t *testing.T) {
+	t.Run("cleanup command exists", func(t *testing.T) {
+		if cleanupCmd == nil {
+			t.Fatal("cleanupCmd is nil")
+		}
+
+		if cleanupCmd.Use != "cleanup" {
+			t.Errorf("cleanupCmd.Use = %v, want 'cleanup'", cleanupCmd.Use)
+		}
+
+		if cleanupCmd.RunE == nil {
+			t.Error("cleanupCmd.RunE is nil")
+		}
+	})
+
+	t.Run("cleanup flags exist", func(t *testing.T) {
+		forceFlag := cleanupCmd.Flags().Lookup("force")
+		if forceFlag == nil {
+			t.Error("--force flag not found")
+		}
+		if forceFlag.DefValue != "false" {
+			t.Errorf("--force default = %v, want 'false'", forceFlag.DefValue)
+		}
+
+		zapFlag := cleanupCmd.Flags().Lookup("zap")
+		if zapFlag == nil {
+			t.Error("--zap flag not found")
+		}
+		if zapFlag.DefValue != "false" {
+			t.Errorf("--zap default = %v, want 'false'", zapFlag.DefValue)
+		}
+
+		autoremoveFlag := cleanupCmd.Flags().Lookup("autoremove")
+		if autoremoveFlag == nil {
+			t.Error("--autoremove flag not found")
+		}
+		if autoremoveFlag.DefValue != "false" {
+			t.Errorf("--autoremove default = %v, want 'false'", autoremoveFlag.DefValue)
+		}
+	})
+}
+
+func TestRunCleanupWithMock(t *testing.T) {
+	t.Run("nothing to cleanup - empty state", func(t *testing.T) {
+		cleanup := setupMockRoot()
+		defer cleanup()
+
+		mock := newMockExecutor()
+		apt.SetExecutor(mock)
+		defer apt.ResetExecutor()
+
+		// Setup empty state
+		tmpDir := t.TempDir()
+		stateFile := filepath.Join(tmpDir, "state.json")
+		apt.SetStatePath(stateFile)
+		defer apt.ResetStatePath()
+
+		// Create Aptfile
+		tmpFile := filepath.Join(tmpDir, "Aptfile")
+		content := "apt curl\napt vim\n"
+		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
+
+		originalPath := aptfilePath
+		defer func() { aptfilePath = originalPath }()
+		aptfilePath = tmpFile
+
+		// Reset flags
+		originalForce := cleanupForce
+		originalZap := cleanupZap
+		originalAutoremove := cleanupAutoremove
+		defer func() {
+			cleanupForce = originalForce
+			cleanupZap = originalZap
+			cleanupAutoremove = originalAutoremove
+		}()
+		cleanupForce = false
+		cleanupZap = false
+		cleanupAutoremove = false
+
+		err := runCleanup(cleanupCmd, []string{})
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("dry-run shows packages to remove", func(t *testing.T) {
+		cleanup := setupMockRoot()
+		defer cleanup()
+
+		mock := newMockExecutor()
+		apt.SetExecutor(mock)
+		defer apt.ResetExecutor()
+
+		// Setup state with packages
+		tmpDir := t.TempDir()
+		stateFile := filepath.Join(tmpDir, "state.json")
+		apt.SetStatePath(stateFile)
+		defer apt.ResetStatePath()
+
+		state := apt.NewState()
+		state.AddPackage("vim")
+		state.AddPackage("curl")
+		state.AddPackage("git") // This one should be removed
+		if err := state.Save(); err != nil {
+			t.Fatalf("Failed to save state: %v", err)
+		}
+
+		// Create Aptfile without git
+		tmpFile := filepath.Join(tmpDir, "Aptfile")
+		content := "apt vim\napt curl\n"
+		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
+
+		originalPath := aptfilePath
+		defer func() { aptfilePath = originalPath }()
+		aptfilePath = tmpFile
+
+		// Reset flags - dry-run mode (force=false)
+		originalForce := cleanupForce
+		originalZap := cleanupZap
+		originalAutoremove := cleanupAutoremove
+		defer func() {
+			cleanupForce = originalForce
+			cleanupZap = originalZap
+			cleanupAutoremove = originalAutoremove
+		}()
+		cleanupForce = false
+		cleanupZap = false
+		cleanupAutoremove = false
+
+		err := runCleanup(cleanupCmd, []string{})
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Verify no apt-get remove was called (dry-run)
+		for _, call := range mock.runCalls {
+			if len(call) >= 2 && call[0] == "apt-get" && call[1] == "remove" {
+				t.Error("apt-get remove should not be called in dry-run mode")
+			}
+		}
+	})
+
+	t.Run("force removes packages", func(t *testing.T) {
+		cleanup := setupMockRoot()
+		defer cleanup()
+
+		mock := newMockExecutor()
+		mock.runFunc = func(name string, args ...string) error {
+			return nil
+		}
+		apt.SetExecutor(mock)
+		defer apt.ResetExecutor()
+
+		// Setup state with packages
+		tmpDir := t.TempDir()
+		stateFile := filepath.Join(tmpDir, "state.json")
+		apt.SetStatePath(stateFile)
+		defer apt.ResetStatePath()
+
+		state := apt.NewState()
+		state.AddPackage("vim")
+		state.AddPackage("curl")
+		state.AddPackage("git") // This one should be removed
+		if err := state.Save(); err != nil {
+			t.Fatalf("Failed to save state: %v", err)
+		}
+
+		// Create Aptfile without git
+		tmpFile := filepath.Join(tmpDir, "Aptfile")
+		content := "apt vim\napt curl\n"
+		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
+
+		originalPath := aptfilePath
+		defer func() { aptfilePath = originalPath }()
+		aptfilePath = tmpFile
+
+		// Set force=true
+		originalForce := cleanupForce
+		originalZap := cleanupZap
+		originalAutoremove := cleanupAutoremove
+		defer func() {
+			cleanupForce = originalForce
+			cleanupZap = originalZap
+			cleanupAutoremove = originalAutoremove
+		}()
+		cleanupForce = true
+		cleanupZap = false
+		cleanupAutoremove = false
+
+		err := runCleanup(cleanupCmd, []string{})
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Verify apt-get remove was called
+		removeCalled := false
+		for _, call := range mock.runCalls {
+			if len(call) >= 3 && call[0] == "apt-get" && call[1] == "remove" && call[3] == "git" {
+				removeCalled = true
+				break
+			}
+		}
+		if !removeCalled {
+			t.Error("Expected apt-get remove to be called for git")
+		}
+
+		// Verify state was updated
+		updatedState, err := apt.LoadState()
+		if err != nil {
+			t.Fatalf("Failed to load state: %v", err)
+		}
+		if updatedState.HasPackage("git") {
+			t.Error("Expected git to be removed from state")
+		}
+	})
+
+	t.Run("force with autoremove", func(t *testing.T) {
+		cleanup := setupMockRoot()
+		defer cleanup()
+
+		mock := newMockExecutor()
+		mock.runFunc = func(name string, args ...string) error {
+			return nil
+		}
+		apt.SetExecutor(mock)
+		defer apt.ResetExecutor()
+
+		// Setup state with packages
+		tmpDir := t.TempDir()
+		stateFile := filepath.Join(tmpDir, "state.json")
+		apt.SetStatePath(stateFile)
+		defer apt.ResetStatePath()
+
+		state := apt.NewState()
+		state.AddPackage("vim")
+		state.AddPackage("git") // This one should be removed
+		if err := state.Save(); err != nil {
+			t.Fatalf("Failed to save state: %v", err)
+		}
+
+		// Create Aptfile without git
+		tmpFile := filepath.Join(tmpDir, "Aptfile")
+		content := "apt vim\n"
+		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
+
+		originalPath := aptfilePath
+		defer func() { aptfilePath = originalPath }()
+		aptfilePath = tmpFile
+
+		// Set force=true and autoremove=true
+		originalForce := cleanupForce
+		originalZap := cleanupZap
+		originalAutoremove := cleanupAutoremove
+		defer func() {
+			cleanupForce = originalForce
+			cleanupZap = originalZap
+			cleanupAutoremove = originalAutoremove
+		}()
+		cleanupForce = true
+		cleanupZap = false
+		cleanupAutoremove = true
+
+		err := runCleanup(cleanupCmd, []string{})
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Verify apt-get autoremove was called
+		autoremoveCalled := false
+		for _, call := range mock.runCalls {
+			if len(call) >= 2 && call[0] == "apt-get" && call[1] == "autoremove" {
+				autoremoveCalled = true
+				break
+			}
+		}
+		if !autoremoveCalled {
+			t.Error("Expected apt-get autoremove to be called")
+		}
+	})
+
+	t.Run("without root privileges and force", func(t *testing.T) {
+		// Don't mock root - should fail
+		if os.Geteuid() == 0 {
+			t.Skip("Skipping test - running as root")
+		}
+
+		tmpDir := t.TempDir()
+		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
+		defer apt.ResetStatePath()
+
+		tmpFile := filepath.Join(tmpDir, "Aptfile")
+		content := "apt vim\n"
+		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
+
+		originalPath := aptfilePath
+		defer func() { aptfilePath = originalPath }()
+		aptfilePath = tmpFile
+
+		// Set force=true - should require root
+		originalForce := cleanupForce
+		originalZap := cleanupZap
+		defer func() {
+			cleanupForce = originalForce
+			cleanupZap = originalZap
+		}()
+		cleanupForce = true
+		cleanupZap = false
+
+		err := runCleanup(cleanupCmd, []string{})
+		if err == nil {
+			t.Error("Expected error without root privileges")
+		}
+	})
+
+	t.Run("invalid aptfile", func(t *testing.T) {
+		cleanup := setupMockRoot()
+		defer cleanup()
+
+		tmpDir := t.TempDir()
+		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
+		defer apt.ResetStatePath()
+
+		tmpFile := filepath.Join(tmpDir, "Aptfile")
+		content := "invalid-directive value\n"
+		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
+
+		originalPath := aptfilePath
+		defer func() { aptfilePath = originalPath }()
+		aptfilePath = tmpFile
+
+		originalForce := cleanupForce
+		defer func() { cleanupForce = originalForce }()
+		cleanupForce = false
+
+		err := runCleanup(cleanupCmd, []string{})
+		if err == nil {
+			t.Error("Expected error for invalid Aptfile")
+		}
+	})
+}
+
+func TestGetPackagesToCleanup(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateFile := filepath.Join(tmpDir, "state.json")
+	apt.SetStatePath(stateFile)
+	defer apt.ResetStatePath()
+
+	// Setup state
+	state := apt.NewState()
+	state.AddPackage("vim")
+	state.AddPackage("curl")
+	state.AddPackage("git")
+	state.AddPackage("htop")
+	if err := state.Save(); err != nil {
+		t.Fatalf("Failed to save state: %v", err)
+	}
+
+	t.Run("some packages to remove", func(t *testing.T) {
+		toRemove, err := getPackagesToCleanup([]string{"vim", "curl"})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if len(toRemove) != 2 {
+			t.Errorf("Expected 2 packages to remove, got %d", len(toRemove))
+		}
+	})
+
+	t.Run("no packages to remove", func(t *testing.T) {
+		toRemove, err := getPackagesToCleanup([]string{"vim", "curl", "git", "htop"})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if len(toRemove) != 0 {
+			t.Errorf("Expected 0 packages to remove, got %d", len(toRemove))
+		}
+	})
+
+	t.Run("all packages to remove", func(t *testing.T) {
+		toRemove, err := getPackagesToCleanup([]string{})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if len(toRemove) != 4 {
+			t.Errorf("Expected 4 packages to remove, got %d", len(toRemove))
+		}
+	})
+}
+
+func TestGetPackagesToZap(t *testing.T) {
+	mock := newMockExecutor()
+	mock.outputFunc = func(name string, args ...string) ([]byte, error) {
+		if name == "apt-mark" && len(args) > 0 && args[0] == "showmanual" {
+			return []byte("vim\ncurl\ngit\nhtop\n"), nil
+		}
+		return nil, nil
+	}
+	apt.SetExecutor(mock)
+	defer apt.ResetExecutor()
+
+	t.Run("some packages to zap", func(t *testing.T) {
+		toZap, err := getPackagesToZap([]string{"vim", "curl"})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if len(toZap) != 2 {
+			t.Errorf("Expected 2 packages to zap, got %d", len(toZap))
+		}
+	})
+
+	t.Run("no packages to zap", func(t *testing.T) {
+		toZap, err := getPackagesToZap([]string{"vim", "curl", "git", "htop"})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if len(toZap) != 0 {
+			t.Errorf("Expected 0 packages to zap, got %d", len(toZap))
+		}
+	})
+}


### PR DESCRIPTION
Add a cleanup command that removes packages no longer listed in the Aptfile. By default, only removes packages that apt-bundle itself installed (tracked in state file), making it safe to use with Docker base images.

Features:
- Dry-run by default (use --force to actually remove)
- --zap flag to remove ALL packages not in Aptfile (with confirmation)
- --autoremove flag to also run apt autoremove
- Add RemovePackage, AutoRemove, GetAllInstalledPackages to apt package