### PR TITLE
Warn when adding PPAs on non-Ubuntu systems

### DIFF
--- a/internal/apt/repositories.go
+++ b/internal/apt/repositories.go
@@ -20,8 +20,31 @@ const (
 // lookPath is the function used to look up command paths (overridable for testing)
 var lookPath = exec.LookPath
 
+// osReleasePath is the path to os-release (overridable for testing)
+var osReleasePath = "/etc/os-release"
+
+// SetOsReleasePath sets osReleasePath (for testing only)
+func SetOsReleasePath(path string) { osReleasePath = path }
+
+// ResetOsReleasePath resets osReleasePath to default (for testing only)
+func ResetOsReleasePath() { osReleasePath = "/etc/os-release" }
+
+// isUbuntu checks if the current system is Ubuntu by reading /etc/os-release
+func isUbuntu() bool {
+	data, err := os.ReadFile(osReleasePath)
+	if err != nil {
+		return false
+	}
+	content := string(data)
+	return strings.Contains(content, "ID=ubuntu") ||
+		strings.Contains(content, "ID_LIKE=ubuntu")
+}
+
 // AddPPA adds a PPA repository using add-apt-repository
 func AddPPA(ppa string) error {
+	if !isUbuntu() {
+		fmt.Println("⚠️  Warning: PPAs are designed for Ubuntu. Using on other distros may cause issues.")
+	}
 	fmt.Printf("Adding PPA: %s\n", ppa)
 
 	if _, err := lookPath("add-apt-repository"); err != nil {

--- a/internal/apt/repositories_test.go
+++ b/internal/apt/repositories_test.go
@@ -11,6 +11,55 @@ import (
 	"github.com/apt-bundle/apt-bundle/internal/testutil"
 )
 
+func TestIsUbuntu(t *testing.T) {
+	dir := t.TempDir()
+	defer ResetOsReleasePath()
+
+	t.Run("ID=ubuntu returns true", func(t *testing.T) {
+		f := filepath.Join(dir, "os-release-ubuntu")
+		if err := os.WriteFile(f, []byte("ID=ubuntu\nVERSION_ID=22.04\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		SetOsReleasePath(f)
+		defer ResetOsReleasePath()
+		if !isUbuntu() {
+			t.Error("expected isUbuntu() true for ID=ubuntu")
+		}
+	})
+
+	t.Run("ID_LIKE=ubuntu returns true", func(t *testing.T) {
+		f := filepath.Join(dir, "os-release-mint")
+		if err := os.WriteFile(f, []byte("ID=linuxmint\nID_LIKE=ubuntu\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		SetOsReleasePath(f)
+		defer ResetOsReleasePath()
+		if !isUbuntu() {
+			t.Error("expected isUbuntu() true for ID_LIKE=ubuntu")
+		}
+	})
+
+	t.Run("non-Ubuntu returns false", func(t *testing.T) {
+		f := filepath.Join(dir, "os-release-debian")
+		if err := os.WriteFile(f, []byte("ID=debian\nVERSION_ID=12\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		SetOsReleasePath(f)
+		defer ResetOsReleasePath()
+		if isUbuntu() {
+			t.Error("expected isUbuntu() false for ID=debian")
+		}
+	})
+
+	t.Run("missing file returns false", func(t *testing.T) {
+		SetOsReleasePath(filepath.Join(dir, "nonexistent"))
+		defer ResetOsReleasePath()
+		if isUbuntu() {
+			t.Error("expected isUbuntu() false when os-release missing")
+		}
+	})
+}
+
 func TestAddPPA(t *testing.T) {
 	t.Run("add-apt-repository not available", func(t *testing.T) {
 		err := AddPPA("ppa:deadsnakes/ppa")


### PR DESCRIPTION
PPAs are Ubuntu-specific. Using them on Debian, Linux Mint, Pop!_OS, or other distros can cause issues. This PR adds a runtime warning when `ppa` directive is used on non-Ubuntu systems.

- Add `isUbuntu()` helper that reads `/etc/os-release` (ID=ubuntu or ID_LIKE=ubuntu)
- `AddPPA()` now prints a warning on non-Ubuntu before proceeding
- Add unit tests for `isUbuntu()`

Made with [Cursor](https://cursor.com)