### PR TITLE
Add apt-bundle sync command (install + cleanup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A declarative, Brewfile-like wrapper for `apt`, inspired by `brew bundle` — no
 
 - 📦 **Declarative Package Management**: Define packages in a simple text file
 - 🔄 **Idempotent Operations**: Safe to run multiple times
+- 🔀 **Sync**: Make system match Aptfile in one command (install + cleanup)
 - 🔑 **Repository & Key Management**: Add PPAs, custom repositories, and GPG keys
 - 📝 **Version Pinning**: Install specific package versions
 - 🚀 **Simple CLI**: Easy-to-use command-line interface
@@ -28,7 +29,7 @@ A declarative, Brewfile-like wrapper for `apt`, inspired by `brew bundle` — no
 | Ansible / Chef | Zero learning curve, no YAML or DSL—just packages and directives |
 | Nix | Works with your existing apt ecosystem; no paradigm shift |
 
-**Key benefits:** The Aptfile is declarative and shareable (commit it to git). Use `apt-bundle dump` to generate an Aptfile from your current system, `apt-bundle check` to validate without installing, and `apt-bundle cleanup` to remove packages no longer in the Aptfile (when using state-tracked installs).
+**Key benefits:** The Aptfile is declarative and shareable (commit it to git). Use `apt-bundle dump` to generate an Aptfile from your current system, `apt-bundle check` to validate without installing, `apt-bundle sync` to make the system match the Aptfile in one command (install + cleanup), and `apt-bundle cleanup` to remove packages no longer in the Aptfile (when using state-tracked installs).
 
 ## Installation
 
@@ -97,6 +98,9 @@ sudo apt-bundle --file /path/to/Aptfile
 
 # Skip updating package lists (useful in CI/CD)
 sudo apt-bundle --no-update
+
+# Make system match Aptfile (install missing, remove no-longer-listed)
+sudo apt-bundle sync
 
 # Check if packages are installed (no root required)
 apt-bundle check

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -67,7 +67,7 @@ func TestRootCmd(t *testing.T) {
 			cmdNames[cmd.Name()] = true
 		}
 
-		expectedCommands := []string{"check", "dump", "install"}
+		expectedCommands := []string{"check", "cleanup", "dump", "install", "sync"}
 		for _, expected := range expectedCommands {
 			if !cmdNames[expected] {
 				t.Errorf("Expected subcommand %q not found", expected)

--- a/internal/commands/sync.go
+++ b/internal/commands/sync.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var syncAutoremove bool
+
+var syncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Make system match Aptfile (install then cleanup)",
+	Long: `Sync makes the system match the Aptfile: install any missing packages and
+repositories, then remove packages that apt-bundle previously installed but are
+no longer listed in the Aptfile (state-based cleanup only; no --zap).
+
+This follows the same "desired state" paradigm as Alpine's apk world file,
+uv sync, and poetry sync: one command to bring the system in line with the
+declared Aptfile.`,
+	RunE: runSync,
+}
+
+func init() {
+	syncCmd.Flags().BoolVar(&syncAutoremove, "autoremove", false, "Run apt autoremove after cleanup")
+	rootCmd.AddCommand(syncCmd)
+}
+
+func runSync(cmd *cobra.Command, args []string) error {
+	if err := checkRoot(); err != nil {
+		return err
+	}
+
+	if err := runInstall(cmd, args); err != nil {
+		return err
+	}
+
+	// Run cleanup with force so removal actually happens (sync is not dry-run)
+	origForce := cleanupForce
+	origAutoremove := cleanupAutoremove
+	cleanupForce = true
+	cleanupAutoremove = syncAutoremove
+	defer func() {
+		cleanupForce = origForce
+		cleanupAutoremove = origAutoremove
+	}()
+	return runCleanup(cmd, args)
+}

--- a/internal/commands/sync_test.go
+++ b/internal/commands/sync_test.go
@@ -1,0 +1,95 @@
+package commands
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/apt-bundle/apt-bundle/internal/apt"
+	"github.com/apt-bundle/apt-bundle/internal/testutil"
+)
+
+func TestSyncCmd(t *testing.T) {
+	t.Run("sync command exists", func(t *testing.T) {
+		if syncCmd == nil {
+			t.Fatal("syncCmd is nil")
+		}
+
+		if syncCmd.Use != "sync" {
+			t.Errorf("syncCmd.Use = %v, want 'sync'", syncCmd.Use)
+		}
+
+		if syncCmd.RunE == nil {
+			t.Error("syncCmd.RunE is nil")
+		}
+	})
+
+	t.Run("sync flags exist", func(t *testing.T) {
+		autoremoveFlag := syncCmd.Flags().Lookup("autoremove")
+		if autoremoveFlag == nil {
+			t.Error("--autoremove flag not found")
+		}
+		if autoremoveFlag.DefValue != "false" {
+			t.Errorf("--autoremove default = %v, want 'false'", autoremoveFlag.DefValue)
+		}
+	})
+}
+
+func TestRunSyncWithMock(t *testing.T) {
+	t.Run("sync runs install then cleanup - nothing to cleanup", func(t *testing.T) {
+		cleanup := setupMockRoot()
+		defer cleanup()
+
+		mock := testutil.NewMockExecutor()
+		mock.RunFunc = func(name string, args ...string) error {
+			return nil
+		}
+		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
+			return nil, errors.New("package not found")
+		}
+		apt.SetExecutor(mock)
+		defer apt.ResetExecutor()
+
+		tmpDir := t.TempDir()
+		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
+		defer apt.ResetStatePath()
+
+		tmpFile := filepath.Join(tmpDir, "Aptfile")
+		content := "apt curl\napt git\n"
+		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
+
+		originalPath := aptfilePath
+		defer func() { aptfilePath = originalPath }()
+		aptfilePath = tmpFile
+
+		err := runSync(syncCmd, []string{})
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("without root privileges", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("Skipping test - running as root")
+		}
+
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "Aptfile")
+		content := "apt curl\n"
+		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
+
+		originalPath := aptfilePath
+		defer func() { aptfilePath = originalPath }()
+		aptfilePath = tmpFile
+
+		err := runSync(syncCmd, []string{})
+		if err == nil {
+			t.Error("runSync() should fail without root privileges")
+		}
+	})
+}


### PR DESCRIPTION
Add a single command that makes the system match the Aptfile: install what's missing, remove what apt-bundle previously installed but is no longer in the Aptfile. Safe by default (state-based cleanup only, no `--zap`).

**Behavior:**
- `sync` = run `install` (repos, keys, packages) then run `cleanup --force` (remove packages tracked by apt-bundle that are no longer in Aptfile)
- Requires root (like install)
- Reuses `--file` / `-f` and `--no-update`
- Optional `--autoremove` to run apt autoremove after cleanup
- Does not expose `--zap` on sync

**Files:**
- `internal/commands/sync.go` — sync command and runSync
- `internal/commands/sync_test.go` — tests
- `internal/commands/root_test.go` — add sync and cleanup to expectedCommands
- `README.md` — document sync in Usage, Features, and Why apt-bundle?

Made with [Cursor](https://cursor.com)