### PR TITLE
feat: add pre-commit hook for format, lint, and build

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Pre-commit hook: format, lint, and verify Go code before commit.
+# Install with: make install-hooks
+
+set -e
+
+# Only run if staged files include Go code
+if ! git diff --cached --name-only | grep -q '\.go$'; then
+  echo "No Go files staged, skipping pre-commit checks"
+  exit 0
+fi
+
+echo "Running pre-commit checks..."
+
+# 1. Autofix (formatting, imports)
+echo "  → golangci-lint --fix"
+go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run --fix
+
+# 2. Re-stage any files modified by autofix
+git add -u
+
+# 3. Verify build
+echo "  → go build"
+go build ./cmd/apt-bundle
+
+# 4. Lint (catch unfixable issues)
+echo "  → golangci-lint"
+go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run
+
+echo "✓ Pre-commit checks passed"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install clean test test-coverage test-coverage-html fmt vet lint help package release-test ci-test
+.PHONY: build install clean test test-coverage test-coverage-html fmt vet lint help package release-test ci-test install-hooks
 
 BINARY_NAME=apt-bundle
 BUILD_DIR=build
@@ -25,6 +25,7 @@ help:
 	@echo "  package             - Build .deb packages locally using nfpm"
 	@echo "  ci-test             - Test CI build step locally (mimics GitHub Actions)"
 	@echo "  release-test        - Test release workflow locally (dry-run)"
+	@echo "  install-hooks       - Install git pre-commit hook (format, lint, build)"
 	@echo "  help                - Show this help message"
 	@echo ""
 	@echo "Environment variables:"
@@ -169,3 +170,10 @@ release-test:
 	@echo "VERSION file contents: $$(cat VERSION)"
 	@echo "This would calculate next patch version based on existing releases"
 	@echo "Run 'make package' to build packages locally"
+
+# Install git pre-commit hook (runs format, lint, build on commit)
+install-hooks:
+	@echo "Installing git pre-commit hook..."
+	@chmod +x .githooks/pre-commit
+	@git config core.hooksPath .githooks
+	@echo "✓ Pre-commit hook installed. Run on: git commit (when Go files are staged)"

--- a/README.md
+++ b/README.md
@@ -243,6 +243,16 @@ make build
 sudo make install
 ```
 
+### Pre-commit Hook
+
+Install the pre-commit hook to automatically format, lint, and verify Go code before each commit:
+
+```bash
+make install-hooks
+```
+
+The hook runs `golangci-lint --fix`, verifies the build, and runs lint. It only runs when Go files are staged (docs-only commits are skipped).
+
 ### Requirements
 
 - Go 1.21 or later


### PR DESCRIPTION
Adds a pre-commit hook that:
- Runs `golangci-lint --fix` to auto-format and fix imports
- Verifies `go build` succeeds
- Runs `golangci-lint` to catch unfixable issues

The hook only runs when Go files are staged (docs-only commits are skipped).

Install with: `make install-hooks`

Made with [Cursor](https://cursor.com)