### PR TITLE
fix: resolve golangci-lint failures (SA5011, gofmt, errcheck)

### DIFF
--- a/internal/apt/keys_test.go
+++ b/internal/apt/keys_test.go
@@ -26,7 +26,9 @@ func TestAddGPGKey(t *testing.T) {
 		})
 
 		keyringPath := filepath.Join(tmpDir, "keyrings")
-		os.MkdirAll(keyringPath, 0755)
+		if err := os.MkdirAll(keyringPath, 0755); err != nil {
+			t.Fatalf("Failed to create keyring dir: %v", err)
+		}
 
 		keyPath, err := AddGPGKey("https://example.com/key.gpg")
 		if err != nil {
@@ -127,7 +129,7 @@ func TestSetHTTPGet(t *testing.T) {
 		}, nil
 	})
 
-	httpGet("http://example.com")
+	_, _ = httpGet("http://example.com")
 	if !customCalled {
 		t.Error("Custom httpGet function was not called")
 	}

--- a/internal/apt/repositories.go
+++ b/internal/apt/repositories.go
@@ -71,12 +71,12 @@ func ResetLookPath() {
 
 // DebRepository represents a parsed deb repository configuration
 type DebRepository struct {
-	Types        string // "deb" or "deb-src"
-	URIs         string
-	Suites       string
-	Components   string
+	Types         string // "deb" or "deb-src"
+	URIs          string
+	Suites        string
+	Components    string
 	Architectures string
-	SignedBy     string // Path to the GPG key file
+	SignedBy      string // Path to the GPG key file
 }
 
 // AddDebRepository adds a deb repository in DEB822 format to /etc/apt/sources.list.d/

--- a/internal/apt/repositories_test.go
+++ b/internal/apt/repositories_test.go
@@ -243,7 +243,9 @@ func TestAddDebRepository(t *testing.T) {
 		keyPath := filepath.Join(tmpDir, "docker.gpg")
 
 		// Create a fake key file
-		os.WriteFile(keyPath, []byte("fake key"), 0644)
+		if err := os.WriteFile(keyPath, []byte("fake key"), 0644); err != nil {
+			t.Fatalf("Failed to create fake key file: %v", err)
+		}
 
 		// This will fail without write permissions to /etc/apt/sources.list.d
 		// but we can verify it doesn't panic and handles the error

--- a/internal/commands/cleanup_test.go
+++ b/internal/commands/cleanup_test.go
@@ -28,24 +28,21 @@ func TestCleanupCmd(t *testing.T) {
 		forceFlag := cleanupCmd.Flags().Lookup("force")
 		if forceFlag == nil {
 			t.Error("--force flag not found")
-		}
-		if forceFlag.DefValue != "false" {
+		} else if forceFlag.DefValue != "false" {
 			t.Errorf("--force default = %v, want 'false'", forceFlag.DefValue)
 		}
 
 		zapFlag := cleanupCmd.Flags().Lookup("zap")
 		if zapFlag == nil {
 			t.Error("--zap flag not found")
-		}
-		if zapFlag.DefValue != "false" {
+		} else if zapFlag.DefValue != "false" {
 			t.Errorf("--zap default = %v, want 'false'", zapFlag.DefValue)
 		}
 
 		autoremoveFlag := cleanupCmd.Flags().Lookup("autoremove")
 		if autoremoveFlag == nil {
 			t.Error("--autoremove flag not found")
-		}
-		if autoremoveFlag.DefValue != "false" {
+		} else if autoremoveFlag.DefValue != "false" {
 			t.Errorf("--autoremove default = %v, want 'false'", autoremoveFlag.DefValue)
 		}
 	})


### PR DESCRIPTION
Addresses pre-existing lint failures reported in [PR #24 Actions run](https://github.com/apt-bundle/apt-bundle/actions/runs/22024951974/job/63639995403?pr=24):

- **internal/commands/cleanup_test.go**: SA5011 possible nil pointer dereference — use `else if` after nil checks so `forceFlag`, `zapFlag`, `autoremoveFlag` are only dereferenced when non-nil.
- **internal/apt/repositories.go**: gofmt — align `DebRepository` struct field comments.
- **internal/apt/repositories_test.go**: errcheck — check `os.WriteFile` error in test.
- **internal/apt/keys_test.go**: errcheck — check `os.MkdirAll` error; explicitly ignore `httpGet` return in `TestSetHTTPGet`.

Made with [Cursor](https://cursor.com)