### PR TITLE
fix: SA5011 possible nil pointer dereference in sync_test.go

### DIFF
--- a/internal/commands/sync_test.go
+++ b/internal/commands/sync_test.go
@@ -29,8 +29,7 @@ func TestSyncCmd(t *testing.T) {
 		autoremoveFlag := syncCmd.Flags().Lookup("autoremove")
 		if autoremoveFlag == nil {
 			t.Error("--autoremove flag not found")
-		}
-		if autoremoveFlag.DefValue != "false" {
+		} else if autoremoveFlag.DefValue != "false" {
 			t.Errorf("--autoremove default = %v, want 'false'", autoremoveFlag.DefValue)
 		}
 	})


### PR DESCRIPTION
Fixes remaining golangci-lint failures in [PR #24 Actions](https://github.com/apt-bundle/apt-bundle/actions/runs/22025098244/job/63640390196?pr=24): use `else if` after nil check so `autoremoveFlag` is only dereferenced when non-nil (same pattern as cleanup_test.go).

Made with [Cursor](https://cursor.com)