### PR TITLE
feat: automate APT repo update and dynamic version in docs

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -40,6 +40,16 @@ jobs:
         id: pages
         uses: actions/configure-pages@v4
 
+      - name: Fetch latest release version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/releases/latest" | \
+            jq -r '.tag_name' | sed 's/^v//')
+          mkdir -p docs/_data
+          echo "apt_repo_version: $VERSION" > docs/_data/version.yml
+
       - name: Build with Jekyll
         run: |
           cd docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,3 +340,36 @@ jobs:
           cat SHA256SUMS >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
+  update-apt-repo:
+    needs: [release, create-release]
+    if: needs.release.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install APT tools
+        run: sudo apt-get update && sudo apt-get install -y dpkg-dev apt-utils
+
+      - name: Update APT repository
+        run: cd docs/repo && ./update-repo.sh ${{ needs.release.outputs.version }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit and push
+        run: |
+          git add docs/repo/
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update APT repository to ${{ needs.release.outputs.version }}"
+            git push
+          fi
+

--- a/docs/_data/version.yml
+++ b/docs/_data/version.yml
@@ -1,0 +1,3 @@
+# Populated at deploy time by deploy-pages workflow from GitHub API.
+# Fallback for local Jekyll builds.
+apt_repo_version: "latest"

--- a/docs/repo/README.md
+++ b/docs/repo/README.md
@@ -1,3 +1,7 @@
+---
+title: APT Repository
+---
+
 # apt-bundle APT Repository
 
 This directory contains the APT repository for the `apt-bundle` package.
@@ -78,7 +82,7 @@ repo/
 
 ## Current Version
 
-The repository currently contains version **0.1.8**.
+The repository currently contains version **{{ site.data.version.apt_repo_version }}**.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Automates APT repository updates and fixes version inconsistency in documentation.

## Changes

### Release workflow
- Add `update-apt-repo` job that runs after each release
- Runs `update-repo.sh` to download .deb packages and regenerate APT metadata
- Commits and pushes updates to `docs/repo/`, keeping APT repo in sync with GitHub releases within minutes

### Deploy Pages workflow
- Add step to fetch latest release version from GitHub API
- Injects version into `docs/_data/version.yml` for Jekyll build

### Documentation
- Replace hardcoded version in `docs/repo/README.md` with Liquid variable `{{ site.data.version.apt_repo_version }}`
- Add `docs/_data/version.yml` fallback for local Jekyll builds

## Result

- APT repository stays in sync with releases automatically
- GitHub Pages docs always show the current version
- Resolves #7

Made with [Cursor](https://cursor.com)