### PR TITLE
refactor: trigger APT repo update on release published event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,36 +340,3 @@ jobs:
           cat SHA256SUMS >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
-  update-apt-repo:
-    needs: [release, create-release]
-    if: needs.release.outputs.skip != 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install APT tools
-        run: sudo apt-get update && sudo apt-get install -y dpkg-dev apt-utils
-
-      - name: Update APT repository
-        run: cd docs/repo && ./update-repo.sh ${{ needs.release.outputs.version }}
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Commit and push
-        run: |
-          git add docs/repo/
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update APT repository to ${{ needs.release.outputs.version }}"
-            git push
-          fi
-

--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -1,0 +1,44 @@
+name: Update APT Repository
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-apt-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install APT tools
+        run: sudo apt-get update && sudo apt-get install -y dpkg-dev apt-utils
+
+      - name: Update APT repository
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${TAG#v}"
+          cd docs/repo && ./update-repo.sh "$VERSION"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit and push
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          git add docs/repo/
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update APT repository to ${TAG}"
+            git push
+          fi


### PR DESCRIPTION
## Summary
Moves the APT repository update from the release workflow to a separate workflow triggered by the `release: types: [published]` event.

## Why
- Fixes the race condition where release assets may not be available immediately after creation (CDN propagation delay)
- Cleaner separation of concerns: release workflow builds/publishes; update-apt-repo workflow syncs after publish

## Changes
- Remove `update-apt-repo` job from release.yml
- Add new update-apt-repo.yml workflow triggered on `release: types: [published]`

Made with [Cursor](https://cursor.com)