### PR TITLE
feat: dump repos and PPAs from sources.list and sources.list.d

### DIFF
--- a/internal/apt/sources.go
+++ b/internal/apt/sources.go
@@ -1,0 +1,212 @@
+package apt
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// SourcesListPath is the path to the main sources.list (overridable for testing)
+var SourcesListPath = "/etc/apt/sources.list"
+
+// SourceEntry represents one repository line to emit in an Aptfile
+type SourceEntry struct {
+	Type        string // "ppa" or "deb"
+	AptfileLine string
+}
+
+// defaultURIs are distro default repository hosts; entries from these are skipped when dumping
+var defaultURIs = []string{
+	"archive.ubuntu.com",
+	"security.ubuntu.com",
+	"deb.debian.org",
+	"ftp.debian.org",
+}
+
+func isDefaultURI(uri string) bool {
+	for _, d := range defaultURIs {
+		if strings.Contains(uri, d) {
+			return true
+		}
+	}
+	return false
+}
+
+// ppaLaunchpadRegex matches PPA deb lines: deb http://ppa.launchpad.net/OWNER/PPA/ubuntu ...
+var ppaLaunchpadRegex = regexp.MustCompile(`ppa\.launchpad\.net/([^/]+)/([^/]+)/`)
+
+func parseDebLineToSource(line string) (SourceEntry, bool) {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return SourceEntry{}, false
+	}
+	// Handle deb and deb-src lines
+	var rest string
+	if strings.HasPrefix(line, "deb-src ") {
+		rest = strings.TrimPrefix(line, "deb-src ")
+	} else if strings.HasPrefix(line, "deb ") {
+		rest = strings.TrimPrefix(line, "deb ")
+	} else {
+		return SourceEntry{}, false
+	}
+	// Extract URI (first field, or after [options])
+	if strings.HasPrefix(rest, "[") {
+		idx := strings.Index(rest, "]")
+		if idx == -1 {
+			return SourceEntry{}, false
+		}
+		rest = strings.TrimSpace(rest[idx+1:])
+	}
+	fields := strings.Fields(rest)
+	if len(fields) < 2 {
+		return SourceEntry{}, false
+	}
+	uri := fields[0]
+	if matches := ppaLaunchpadRegex.FindStringSubmatch(uri); len(matches) >= 3 {
+		owner := matches[1]
+		ppa := matches[2]
+		return SourceEntry{Type: "ppa", AptfileLine: "ppa ppa:" + owner + "/" + ppa}, true
+	}
+	if isDefaultURI(uri) {
+		return SourceEntry{}, false
+	}
+	return SourceEntry{Type: "deb", AptfileLine: line}, true
+}
+
+// ListCustomSources reads sources.list and sources.list.d and returns Aptfile lines for custom repos
+func ListCustomSources(sourcesListPath, sourcesDir string) ([]SourceEntry, error) {
+	var entries []SourceEntry
+	seen := make(map[string]bool)
+
+	// Read main sources.list
+	if data, err := os.ReadFile(sourcesListPath); err == nil {
+		lines := strings.Split(string(data), "\n")
+		for _, line := range lines {
+			if e, ok := parseDebLineToSource(line); ok && !seen[e.AptfileLine] {
+				seen[e.AptfileLine] = true
+				entries = append(entries, e)
+			}
+		}
+	}
+	// Ignore read error (e.g. missing file)
+
+	// Read sources.list.d
+	dirEntries, err := os.ReadDir(sourcesDir)
+	if err != nil {
+		return entries, nil // directory missing is ok
+	}
+	for _, de := range dirEntries {
+		if de.IsDir() {
+			continue
+		}
+		name := de.Name()
+		if !strings.HasSuffix(name, ".list") && !strings.HasSuffix(name, ".sources") {
+			continue
+		}
+		path := filepath.Join(sourcesDir, name)
+		if strings.HasSuffix(name, ".list") {
+			listEntries, err := readListFile(path)
+			if err != nil {
+				continue
+			}
+			for _, e := range listEntries {
+				if !seen[e.AptfileLine] {
+					seen[e.AptfileLine] = true
+					entries = append(entries, e)
+				}
+			}
+		} else {
+			sourceEntries, err := readDEB822File(path)
+			if err != nil {
+				continue
+			}
+			for _, e := range sourceEntries {
+				if !seen[e.AptfileLine] {
+					seen[e.AptfileLine] = true
+					entries = append(entries, e)
+				}
+			}
+		}
+	}
+
+	// Stable order: ppa first, then deb; same type sorted by line
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Type != entries[j].Type {
+			return entries[i].Type < entries[j].Type
+		}
+		return entries[i].AptfileLine < entries[j].AptfileLine
+	})
+	return entries, nil
+}
+
+func readListFile(path string) ([]SourceEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var entries []SourceEntry
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		if e, ok := parseDebLineToSource(sc.Text()); ok {
+			entries = append(entries, e)
+		}
+	}
+	return entries, sc.Err()
+}
+
+// readDEB822File parses a DEB822 .sources file and returns Aptfile entries (deb only; PPA not in .sources typically)
+func readDEB822File(path string) ([]SourceEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	// Simple key-value parse: Types, URIs, Suites, Components, Architectures
+	var types, uris, suites, components, architectures string
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if idx := strings.Index(line, ":"); idx > 0 {
+			key := strings.TrimSpace(line[:idx])
+			val := strings.TrimSpace(line[idx+1:])
+			switch key {
+			case "Types":
+				types = val
+			case "URIs":
+				uris = val
+			case "Suites":
+				suites = val
+			case "Components":
+				components = val
+			case "Architectures":
+				architectures = val
+			}
+		}
+	}
+	if uris == "" || suites == "" {
+		return nil, nil
+	}
+	if isDefaultURI(uris) {
+		return nil, nil
+	}
+	// Build deb line: [arch=X] URI Suite Components
+	debType := "deb"
+	if types == "deb-src" {
+		debType = "deb-src"
+	}
+	line := debType + " "
+	if architectures != "" {
+		line += "[arch=" + architectures + "] "
+	}
+	line += uris + " " + suites
+	if components != "" {
+		line += " " + components
+	}
+	return []SourceEntry{{Type: "deb", AptfileLine: line}}, nil
+}

--- a/internal/apt/sources_test.go
+++ b/internal/apt/sources_test.go
@@ -1,0 +1,103 @@
+package apt
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestListCustomSources(t *testing.T) {
+	tmpDir := t.TempDir()
+	sourcesList := filepath.Join(tmpDir, "sources.list")
+	sourcesDir := filepath.Join(tmpDir, "sources.list.d")
+	if err := os.MkdirAll(sourcesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty: no custom sources
+	entries, err := ListCustomSources(sourcesList, sourcesDir)
+	if err != nil {
+		t.Fatalf("ListCustomSources: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(entries))
+	}
+
+	// Write a .list file with one PPA and one deb
+	listPath := filepath.Join(sourcesDir, "custom.list")
+	content := `# comment
+deb http://ppa.launchpad.net/ondrej/php/ubuntu jammy main
+deb [arch=amd64] https://download.docker.com/linux/ubuntu jammy stable
+`
+	if err := os.WriteFile(listPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	entries, err = ListCustomSources(sourcesList, sourcesDir)
+	if err != nil {
+		t.Fatalf("ListCustomSources: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(entries))
+	}
+	var ppaFound, debFound bool
+	for _, e := range entries {
+		if e.Type == "ppa" && strings.Contains(e.AptfileLine, "ppa:ondrej/php") {
+			ppaFound = true
+		}
+		if e.Type == "deb" && strings.Contains(e.AptfileLine, "download.docker.com") {
+			debFound = true
+		}
+	}
+	if !ppaFound {
+		t.Error("expected ppa entry for ondrej/php")
+	}
+	if !debFound {
+		t.Error("expected deb entry for docker")
+	}
+
+	// Write a .sources file (DEB822)
+	sourcesPath := filepath.Join(sourcesDir, "test.sources")
+	sourcesContent := `Types: deb
+URIs: https://example.com/apt
+Suites: focal
+Components: main
+Architectures: amd64
+`
+	if err := os.WriteFile(sourcesPath, []byte(sourcesContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	entries, err = ListCustomSources(sourcesList, sourcesDir)
+	if err != nil {
+		t.Fatalf("ListCustomSources: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Errorf("expected 3 entries after .sources, got %d", len(entries))
+	}
+}
+
+func TestListCustomSources_skipsDefault(t *testing.T) {
+	tmpDir := t.TempDir()
+	sourcesList := filepath.Join(tmpDir, "sources.list")
+	sourcesDir := filepath.Join(tmpDir, "sources.list.d")
+	if err := os.MkdirAll(sourcesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := `deb http://archive.ubuntu.com/ubuntu jammy main
+deb http://security.ubuntu.com/ubuntu jammy-security main
+deb https://custom.example.com/ubuntu jammy main
+`
+	if err := os.WriteFile(sourcesList, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := ListCustomSources(sourcesList, sourcesDir)
+	if err != nil {
+		t.Fatalf("ListCustomSources: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected 1 custom entry (skip defaults), got %d", len(entries))
+	}
+	if len(entries) > 0 && !strings.Contains(entries[0].AptfileLine, "custom.example.com") {
+		t.Errorf("expected custom.example.com entry, got %s", entries[0].AptfileLine)
+	}
+}

--- a/internal/commands/dump.go
+++ b/internal/commands/dump.go
@@ -36,6 +36,18 @@ func runDump(cmd *cobra.Command, args []string) error {
 		fmt.Println("apt", pkg)
 	}
 
+	// Emit custom repositories (PPAs and deb) from sources.list and sources.list.d
+	sources, err := apt.ListCustomSources(apt.SourcesListPath, apt.SourcesDir)
+	if err != nil {
+		return fmt.Errorf("failed to list custom sources: %w", err)
+	}
+	if len(sources) > 0 {
+		fmt.Println()
+		for _, e := range sources {
+			fmt.Println(e.AptfileLine)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Extend dump to list custom PPAs and deb repositories so `apt-bundle dump` can produce a full Aptfile.

- Add internal/apt/sources.go: ListCustomSources() reading sources.list and sources.list.d
- Parse .list (one-line deb) and .sources (DEB822); classify PPA vs deb; skip default distro URIs
- Emit ppa/deb Aptfile lines after packages; add sources_test.go

PR 2 of roadmap.

Made with [Cursor](https://cursor.com)