### PR TITLE
PR 3: Lock file / version pinning

### DIFF
--- a/internal/apt/packages.go
+++ b/internal/apt/packages.go
@@ -2,6 +2,7 @@ package apt
 
 import (
 	"fmt"
+	"strings"
 )
 
 // IsPackageInstalled checks if a package is installed on the system
@@ -61,6 +62,15 @@ func AutoRemove() error {
 
 	fmt.Println("✓ Orphaned dependencies removed")
 	return nil
+}
+
+// GetInstalledVersion returns the installed version of a package, or empty string if not installed
+func GetInstalledVersion(packageName string) (string, error) {
+	output, err := runCommandWithOutput("dpkg-query", "-W", "-f=${Version}", packageName)
+	if err != nil {
+		return "", nil
+	}
+	return strings.TrimSpace(string(output)), nil
 }
 
 // GetAllInstalledPackages returns a list of all manually installed packages

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -2,6 +2,9 @@ package commands
 
 import (
 	"fmt"
+	"os"
+	"sort"
+	"strings"
 
 	"github.com/apt-bundle/apt-bundle/internal/apt"
 	"github.com/apt-bundle/apt-bundle/internal/aptfile"
@@ -9,7 +12,9 @@ import (
 )
 
 var (
-	noUpdate bool
+	noUpdate   bool
+	installLock bool
+	installLocked bool
 )
 
 var installCmd = &cobra.Command{
@@ -24,6 +29,8 @@ var installCmd = &cobra.Command{
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&noUpdate, "no-update", false, "Skip updating package lists before installing")
+	installCmd.Flags().BoolVar(&installLock, "lock", false, "After install, write Aptfile.lock with current package versions")
+	installCmd.Flags().BoolVar(&installLocked, "locked", false, "Install only versions from Aptfile.lock (fail if lock missing)")
 	rootCmd.AddCommand(installCmd)
 	rootCmd.RunE = runInstall
 }
@@ -86,24 +93,36 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	}
 
 	packagesToInstall := []string{}
-	for _, entry := range entries {
-		if entry.Type == aptfile.EntryTypeApt {
-			packagesToInstall = append(packagesToInstall, entry.Value)
+	if installLocked {
+		specs, err := ReadLockFile()
+		if err != nil {
+			return err
+		}
+		packagesToInstall = specs
+	} else {
+		for _, entry := range entries {
+			if entry.Type == aptfile.EntryTypeApt {
+				packagesToInstall = append(packagesToInstall, entry.Value)
+			}
 		}
 	}
 
 	if len(packagesToInstall) > 0 {
 		fmt.Printf("Installing %d packages...\n", len(packagesToInstall))
 		for _, pkg := range packagesToInstall {
-			installed, err := apt.IsPackageInstalled(pkg)
+			pkgName := pkg
+			if idx := strings.Index(pkg, "="); idx > 0 {
+				pkgName = pkg[:idx]
+			}
+			installed, err := apt.IsPackageInstalled(pkgName)
 			if err != nil {
-				fmt.Printf("Warning: Could not check if %s is installed: %v\n", pkg, err)
+				fmt.Printf("Warning: Could not check if %s is installed: %v\n", pkgName, err)
 			}
 			if installed {
-				fmt.Printf("✓ Package %s is already installed\n", pkg)
+				fmt.Printf("✓ Package %s is already installed\n", pkgName)
 				// Track the package in state even if already installed
 				// (user may have installed it manually before using apt-bundle)
-				state.AddPackage(pkg)
+				state.AddPackage(pkgName)
 				continue
 			}
 
@@ -112,7 +131,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			}
 
 			// Track successfully installed package in state
-			state.AddPackage(pkg)
+			state.AddPackage(pkgName)
 		}
 		fmt.Println("✓ All packages installed successfully")
 	} else {
@@ -124,5 +143,40 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to save state: %w", err)
 	}
 
+	if installLock && len(packagesToInstall) > 0 {
+		if err := writeLockFileFromPackages(packagesToInstall); err != nil {
+			return fmt.Errorf("failed to write lock file: %w", err)
+		}
+	}
+
 	return nil
+}
+
+func writeLockFileFromPackages(packages []string) error {
+	type pkgVer struct {
+		pkg string
+		ver string
+	}
+	var locked []pkgVer
+	for _, pkg := range packages {
+		pkgName := pkg
+		if idx := strings.Index(pkg, "="); idx > 0 {
+			pkgName = pkg[:idx]
+		}
+		ver, err := apt.GetInstalledVersion(pkgName)
+		if err != nil || ver == "" {
+			continue
+		}
+		locked = append(locked, pkgVer{pkg: pkgName, ver: ver})
+	}
+	if len(locked) == 0 {
+		return nil
+	}
+	sort.Slice(locked, func(i, j int) bool { return locked[i].pkg < locked[j].pkg })
+	path := getLockFilePath()
+	var lines []string
+	for _, pv := range locked {
+		lines = append(lines, pv.pkg+"="+pv.ver)
+	}
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0644)
 }

--- a/internal/commands/lock.go
+++ b/internal/commands/lock.go
@@ -1,0 +1,105 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/apt-bundle/apt-bundle/internal/apt"
+	"github.com/apt-bundle/apt-bundle/internal/aptfile"
+	"github.com/spf13/cobra"
+)
+
+var lockCmd = &cobra.Command{
+	Use:   "lock",
+	Short: "Generate Aptfile.lock from current installed versions of Aptfile packages",
+	Long: `Lock reads the Aptfile, queries installed versions of each package,
+and writes Aptfile.lock for reproducible installs. Does not require root.
+Use 'apt-bundle install --locked' to install only locked versions.`,
+	RunE: runLock,
+}
+
+func init() {
+	rootCmd.AddCommand(lockCmd)
+}
+
+func getLockFilePath() string {
+	dir := filepath.Dir(aptfilePath)
+	return filepath.Join(dir, "Aptfile.lock")
+}
+
+func runLock(cmd *cobra.Command, args []string) error {
+	entries, err := aptfile.Parse(aptfilePath)
+	if err != nil {
+		return fmt.Errorf("failed to parse Aptfile: %w", err)
+	}
+
+	var packages []string
+	for _, e := range entries {
+		if e.Type == aptfile.EntryTypeApt {
+			packages = append(packages, e.Value)
+		}
+	}
+	if len(packages) == 0 {
+		return fmt.Errorf("no packages in Aptfile")
+	}
+
+	type pkgVer struct {
+		pkg string
+		ver string
+	}
+	var locked []pkgVer
+	for _, pkg := range packages {
+		// Strip version if present for lookup (e.g. "nano=2.9.3" -> "nano")
+		pkgName := pkg
+		if idx := strings.Index(pkg, "="); idx > 0 {
+			pkgName = pkg[:idx]
+		}
+		ver, err := apt.GetInstalledVersion(pkgName)
+		if err != nil || ver == "" {
+			fmt.Printf("Warning: %s not installed, skipping in lock file\n", pkgName)
+			continue
+		}
+		locked = append(locked, pkgVer{pkg: pkgName, ver: ver})
+	}
+	if len(locked) == 0 {
+		return fmt.Errorf("no installed packages from Aptfile to lock")
+	}
+
+	sort.Slice(locked, func(i, j int) bool { return locked[i].pkg < locked[j].pkg })
+	path := getLockFilePath()
+	var lines []string
+	for _, pv := range locked {
+		lines = append(lines, pv.pkg+"="+pv.ver)
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+		return fmt.Errorf("failed to write lock file: %w", err)
+	}
+	fmt.Printf("Wrote %d package versions to %s\n", len(locked), path)
+	return nil
+}
+
+// ReadLockFile returns package specs (pkg=version) from the lock file, or nil if missing/invalid
+func ReadLockFile() ([]string, error) {
+	path := getLockFilePath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("lock file not found: %s (run 'apt-bundle lock' first)", path)
+		}
+		return nil, err
+	}
+	var specs []string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.Contains(line, "=") {
+			specs = append(specs, line)
+		}
+	}
+	return specs, nil
+}

--- a/internal/commands/lock_test.go
+++ b/internal/commands/lock_test.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLockCmd(t *testing.T) {
+	t.Run("lock command exists", func(t *testing.T) {
+		if lockCmd == nil {
+			t.Fatal("lockCmd is nil")
+		}
+		if lockCmd.Use != "lock" {
+			t.Errorf("lockCmd.Use = %v, want 'lock'", lockCmd.Use)
+		}
+		if lockCmd.RunE == nil {
+			t.Error("lockCmd.RunE is nil")
+		}
+	})
+}
+
+func TestReadLockFile(t *testing.T) {
+	t.Run("missing lock file returns error", func(t *testing.T) {
+		orig := aptfilePath
+		defer func() { aptfilePath = orig }()
+		aptfilePath = "/nonexistent/Aptfile"
+		_, err := ReadLockFile()
+		if err == nil {
+			t.Error("ReadLockFile should error when lock file missing")
+		}
+	})
+	t.Run("read valid lock file", func(t *testing.T) {
+		dir := t.TempDir()
+		lockPath := filepath.Join(dir, "Aptfile.lock")
+		if err := os.WriteFile(lockPath, []byte("curl=7.68.0\nvim=2:8.2\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		orig := aptfilePath
+		defer func() { aptfilePath = orig }()
+		aptfilePath = filepath.Join(dir, "Aptfile")
+		if err := os.WriteFile(aptfilePath, []byte("apt curl\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		specs, err := ReadLockFile()
+		if err != nil {
+			t.Fatalf("ReadLockFile: %v", err)
+		}
+		if len(specs) != 2 {
+			t.Errorf("expected 2 specs, got %d", len(specs))
+		}
+	})
+}

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -67,7 +67,7 @@ func TestRootCmd(t *testing.T) {
 			cmdNames[cmd.Name()] = true
 		}
 
-		expectedCommands := []string{"check", "cleanup", "dump", "install", "sync"}
+		expectedCommands := []string{"check", "cleanup", "dump", "install", "lock", "sync"}
 		for _, expected := range expectedCommands {
 			if !cmdNames[expected] {
 				t.Errorf("Expected subcommand %q not found", expected)


### PR DESCRIPTION
Implements optional lock file for reproducible installs:
- New `apt-bundle lock` command to generate Aptfile.lock from current Aptfile and installed versions
- `apt-bundle install --lock` runs install then writes lock file
- `apt-bundle install --locked` installs only versions from lock file (Aptfile still used for repos/keys)
- Lock file format: one `pkg=version` line per package (sorted)
- Added GetInstalledVersion in internal/apt/packages.go; lock and install tests

Made with [Cursor](https://cursor.com)