### PR TITLE
PR 4: Outdated command

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ sudo apt-bundle sync
 # Check if packages are installed (no root required)
 apt-bundle check
 
+# List packages with available upgrades (exit 1 if any; for CI)
+apt-bundle outdated
+
 # Generate an Aptfile from current system
 apt-bundle dump > Aptfile
 ```

--- a/internal/apt/packages.go
+++ b/internal/apt/packages.go
@@ -2,6 +2,7 @@ package apt
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -71,6 +72,38 @@ func GetInstalledVersion(packageName string) (string, error) {
 		return "", nil
 	}
 	return strings.TrimSpace(string(output)), nil
+}
+
+// candidateVersionRE parses "Candidate: version" from apt-cache policy output
+var candidateVersionRE = regexp.MustCompile(`(?m)^\s*Candidate:\s*(.+)$`)
+
+// GetCandidateVersion returns the candidate (available) version for a package, or empty if unknown
+func GetCandidateVersion(packageName string) (string, error) {
+	output, err := runCommandWithOutput("apt-cache", "policy", packageName)
+	if err != nil {
+		return "", err
+	}
+	matches := candidateVersionRE.FindStringSubmatch(string(output))
+	if len(matches) < 2 {
+		return "", nil
+	}
+	return strings.TrimSpace(matches[1]), nil
+}
+
+// CompareVersions compares two Debian package versions. Returns -1 if a < b, 0 if a == b, 1 if a > b
+func CompareVersions(a, b string) (int, error) {
+	if a == b {
+		return 0, nil
+	}
+	_, err := runCommandWithOutput("dpkg", "--compare-versions", a, "lt", b)
+	if err == nil {
+		return -1, nil
+	}
+	_, err = runCommandWithOutput("dpkg", "--compare-versions", a, "gt", b)
+	if err == nil {
+		return 1, nil
+	}
+	return 0, fmt.Errorf("dpkg version comparison failed for %q and %q", a, b)
 }
 
 // GetAllInstalledPackages returns a list of all manually installed packages

--- a/internal/commands/outdated.go
+++ b/internal/commands/outdated.go
@@ -1,0 +1,102 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/apt-bundle/apt-bundle/internal/apt"
+	"github.com/apt-bundle/apt-bundle/internal/aptfile"
+	"github.com/spf13/cobra"
+)
+
+var outdatedCmd = &cobra.Command{
+	Use:   "outdated",
+	Short: "List Aptfile packages that have available upgrades",
+	Long: `Outdated compares installed versions of Aptfile packages to the
+candidate (available) versions and lists packages that have upgrades available.
+Exit code is 0 only when no packages are outdated (suitable for CI).`,
+	RunE: runOutdated,
+}
+
+func init() {
+	rootCmd.AddCommand(outdatedCmd)
+}
+
+// OutdatedEntry holds one outdated package line (name, installed, candidate)
+type OutdatedEntry struct {
+	Name      string
+	Installed string
+	Candidate string
+}
+
+// collectOutdated returns Aptfile packages that have a newer candidate version,
+// and the number of apt entries in the Aptfile.
+func collectOutdated(aptFilePath string) (outdated []OutdatedEntry, numApt int, err error) {
+	entries, err := aptfile.Parse(aptFilePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, 0, fmt.Errorf("Aptfile not found: %s", aptFilePath)
+		}
+		return nil, 0, fmt.Errorf("failed to parse Aptfile: %w", err)
+	}
+
+	var packages []string
+	for _, e := range entries {
+		if e.Type != aptfile.EntryTypeApt {
+			continue
+		}
+		numApt++
+		pkg := strings.SplitN(e.Value, "=", 2)[0]
+		packages = append(packages, pkg)
+	}
+
+	for _, pkg := range packages {
+		installed, err := apt.GetInstalledVersion(pkg)
+		if err != nil {
+			return nil, numApt, fmt.Errorf("failed to get installed version of %s: %w", pkg, err)
+		}
+		if installed == "" {
+			continue
+		}
+		candidate, err := apt.GetCandidateVersion(pkg)
+		if err != nil {
+			return nil, numApt, fmt.Errorf("failed to get candidate version of %s: %w", pkg, err)
+		}
+		if candidate == "" || candidate == "(none)" {
+			continue
+		}
+		cmp, err := apt.CompareVersions(installed, candidate)
+		if err != nil {
+			return nil, numApt, fmt.Errorf("version comparison for %s: %w", pkg, err)
+		}
+		if cmp < 0 {
+			outdated = append(outdated, OutdatedEntry{pkg, installed, candidate})
+		}
+	}
+
+	sort.Slice(outdated, func(i, j int) bool { return outdated[i].Name < outdated[j].Name })
+	return outdated, numApt, nil
+}
+
+func runOutdated(cmd *cobra.Command, args []string) error {
+	outdated, numApt, err := collectOutdated(aptfilePath)
+	if err != nil {
+		return err
+	}
+
+	if len(outdated) == 0 {
+		if numApt == 0 {
+			fmt.Println("No apt packages in Aptfile.")
+		}
+		return nil
+	}
+
+	for _, e := range outdated {
+		fmt.Printf("%s (installed: %s, available: %s)\n", e.Name, e.Installed, e.Candidate)
+	}
+	os.Exit(1)
+	return nil
+}

--- a/internal/commands/outdated_test.go
+++ b/internal/commands/outdated_test.go
@@ -1,0 +1,115 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/apt-bundle/apt-bundle/internal/apt"
+	"github.com/apt-bundle/apt-bundle/internal/testutil"
+)
+
+func TestOutdatedCmd(t *testing.T) {
+	t.Run("outdated command exists", func(t *testing.T) {
+		if outdatedCmd == nil {
+			t.Fatal("outdatedCmd is nil")
+		}
+		if outdatedCmd.Use != "outdated" {
+			t.Errorf("outdatedCmd.Use = %v, want 'outdated'", outdatedCmd.Use)
+		}
+		if outdatedCmd.RunE == nil {
+			t.Error("outdatedCmd.RunE is nil")
+		}
+	})
+}
+
+func TestRunOutdated(t *testing.T) {
+	dir := t.TempDir()
+	aptPath := filepath.Join(dir, "Aptfile")
+	origPath := aptfilePath
+	aptfilePath = aptPath
+	defer func() { aptfilePath = origPath }()
+
+	t.Run("no outdated packages", func(t *testing.T) {
+		if err := os.WriteFile(aptPath, []byte("apt curl\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		mock := testutil.NewMockExecutor()
+		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
+			switch name {
+			case "dpkg-query":
+				if len(args) >= 4 && args[2] == "${Version}" && args[3] == "curl" {
+					return []byte("1.0\n"), nil
+				}
+			case "apt-cache":
+				if len(args) >= 2 && args[0] == "policy" && args[1] == "curl" {
+					return []byte("curl:\n  Installed: 1.0\n  Candidate: 1.0\n"), nil
+				}
+			case "dpkg":
+				// 1.0 lt 1.0 -> false, so command fails (err != nil)
+				return nil, errors.New("compare failed")
+			}
+			return nil, errors.New("unexpected command: " + name)
+		}
+		apt.SetExecutor(mock)
+		defer apt.ResetExecutor()
+
+		var buf bytes.Buffer
+		oldOut, oldErr := os.Stdout, os.Stderr
+		os.Stdout = &buf
+		os.Stderr = &buf
+		defer func() { os.Stdout, os.Stderr = oldOut, oldErr }()
+
+		err := runOutdated(outdatedCmd, nil)
+		if err != nil {
+			t.Fatalf("runOutdated: %v", err)
+		}
+		// Should not exit 1 when nothing outdated; we didn't call os.Exit
+		if buf.String() != "" {
+			t.Logf("output: %s", buf.String())
+		}
+	})
+
+	t.Run("one outdated package", func(t *testing.T) {
+		if err := os.WriteFile(aptPath, []byte("apt curl\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		mock := testutil.NewMockExecutor()
+		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
+			switch name {
+			case "dpkg-query":
+				if len(args) >= 4 && args[3] == "curl" {
+					return []byte("1.0\n"), nil
+				}
+			case "apt-cache":
+				if len(args) >= 2 && args[0] == "policy" && args[1] == "curl" {
+					return []byte("curl:\n  Installed: 1.0\n  Candidate: 1.1\n"), nil
+				}
+			case "dpkg":
+				if len(args) >= 4 && args[0] == "--compare-versions" && args[1] == "1.0" && args[2] == "lt" && args[3] == "1.1" {
+					return []byte{}, nil
+				}
+				return nil, errors.New("comparison false")
+			}
+			return nil, errors.New("unexpected: " + name)
+		}
+		apt.SetExecutor(mock)
+		defer apt.ResetExecutor()
+
+		outdated, numApt, err := collectOutdated(aptPath)
+		if err != nil {
+			t.Fatalf("collectOutdated: %v", err)
+		}
+		if numApt != 1 {
+			t.Errorf("numApt = %d, want 1", numApt)
+		}
+		if len(outdated) != 1 {
+			t.Fatalf("len(outdated) = %d, want 1", len(outdated))
+		}
+		if outdated[0].Name != "curl" || outdated[0].Installed != "1.0" || outdated[0].Candidate != "1.1" {
+			t.Errorf("outdated[0] = %+v", outdated[0])
+		}
+	})
+}

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -67,7 +67,7 @@ func TestRootCmd(t *testing.T) {
 			cmdNames[cmd.Name()] = true
 		}
 
-		expectedCommands := []string{"check", "cleanup", "dump", "install", "lock", "sync"}
+		expectedCommands := []string{"check", "cleanup", "dump", "install", "lock", "outdated", "sync"}
 		for _, expected := range expectedCommands {
 			if !cmdNames[expected] {
 				t.Errorf("Expected subcommand %q not found", expected)


### PR DESCRIPTION
Implements `apt-bundle outdated`:
- Compares installed versions of Aptfile packages to candidate (available) versions
- Lists packages that have upgrades available
- Exit code 0 only when nothing outdated (for CI)
- GetCandidateVersion (apt-cache policy) and CompareVersions (dpkg) in internal/apt/packages.go
- Tests with mock executor; README updated

Made with [Cursor](https://cursor.com)