### PR TITLE
PR 5: Doctor (with validate, --aptfile-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ sudo apt-bundle sync
 # Check if packages are installed (no root required)
 apt-bundle check
 
+# Validate Aptfile and check environment (apt-get, add-apt-repository, state)
+apt-bundle doctor
+# Only validate Aptfile (no environment checks)
+apt-bundle doctor --aptfile-only
+
 # List packages with available upgrades (exit 1 if any; for CI)
 apt-bundle outdated
 

--- a/internal/commands/doctor.go
+++ b/internal/commands/doctor.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/apt-bundle/apt-bundle/internal/apt"
+	"github.com/apt-bundle/apt-bundle/internal/aptfile"
+	"github.com/spf13/cobra"
+)
+
+var doctorAptfileOnly bool
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Validate Aptfile and check environment",
+	Long: `Doctor runs Aptfile validation (parse, unknown directives, syntax) and
+environment checks (PATH, apt-get, add-apt-repository, state file). Use
+--aptfile-only to run only Aptfile validation. Exit non-zero if any check fails.`,
+	RunE: runDoctor,
+}
+
+func init() {
+	rootCmd.AddCommand(doctorCmd)
+	doctorCmd.Flags().BoolVar(&doctorAptfileOnly, "aptfile-only", false, "Only validate Aptfile; skip environment checks")
+}
+
+func runDoctor(cmd *cobra.Command, args []string) error {
+	var failed bool
+
+	// Aptfile validation
+	entries, err := aptfile.Parse(aptfilePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(os.Stderr, "⚠ Aptfile not found: %s (skipping validation)\n", aptfilePath)
+		} else {
+			fmt.Fprintf(os.Stderr, "✗ Aptfile validation failed: %v\n", err)
+			failed = true
+		}
+	} else {
+		fmt.Printf("✓ Aptfile valid (%d entries)\n", len(entries))
+	}
+
+	if doctorAptfileOnly {
+		if failed {
+			os.Exit(1)
+		}
+		return nil
+	}
+
+	// Environment checks
+	if _, err := exec.LookPath("apt-get"); err != nil {
+		fmt.Fprintf(os.Stderr, "✗ apt-get not found on PATH\n")
+		failed = true
+	} else {
+		fmt.Println("✓ apt-get available")
+	}
+
+	if _, err := exec.LookPath("add-apt-repository"); err != nil {
+		fmt.Fprintf(os.Stderr, "✗ add-apt-repository not found on PATH\n")
+		failed = true
+	} else {
+		fmt.Println("✓ add-apt-repository available")
+	}
+
+	if _, err := apt.LoadState(); err != nil {
+		fmt.Fprintf(os.Stderr, "✗ state file: %v (path: %s)\n", err, apt.StateDir)
+		failed = true
+	} else {
+		fmt.Println("✓ state file readable")
+	}
+
+	if failed {
+		os.Exit(1)
+	}
+	return nil
+}

--- a/internal/commands/doctor_test.go
+++ b/internal/commands/doctor_test.go
@@ -1,0 +1,70 @@
+package commands
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDoctorCmd(t *testing.T) {
+	t.Run("doctor command exists", func(t *testing.T) {
+		if doctorCmd == nil {
+			t.Fatal("doctorCmd is nil")
+		}
+		if doctorCmd.Use != "doctor" {
+			t.Errorf("doctorCmd.Use = %v, want 'doctor'", doctorCmd.Use)
+		}
+		f := doctorCmd.Flags().Lookup("aptfile-only")
+		if f == nil {
+			t.Fatal("--aptfile-only flag not found")
+		}
+	})
+}
+
+func TestRunDoctor(t *testing.T) {
+	dir := t.TempDir()
+	origPath := aptfilePath
+	aptfilePath = filepath.Join(dir, "Aptfile")
+	defer func() { aptfilePath = origPath }()
+
+	t.Run("valid Aptfile and --aptfile-only", func(t *testing.T) {
+		if err := os.WriteFile(aptfilePath, []byte("apt curl\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		doctorAptfileOnly = true
+		defer func() { doctorAptfileOnly = false }()
+
+		var buf bytes.Buffer
+		os.Stdout = &buf
+		os.Stderr = &buf
+		defer func() { os.Stdout, os.Stderr = os.Stdout, os.Stderr }()
+
+		err := runDoctor(doctorCmd, nil)
+		if err != nil {
+			t.Fatalf("runDoctor: %v", err)
+		}
+		out := buf.String()
+		if !bytes.Contains([]byte(out), []byte("Aptfile valid")) {
+			t.Errorf("output should contain 'Aptfile valid', got: %s", out)
+		}
+	})
+
+	t.Run("missing Aptfile with --aptfile-only warns and continues", func(t *testing.T) {
+		aptfilePath = filepath.Join(dir, "nonexistent-Aptfile")
+		doctorAptfileOnly = true
+		defer func() { doctorAptfileOnly = false; aptfilePath = filepath.Join(dir, "Aptfile") }()
+
+		var buf bytes.Buffer
+		os.Stderr = &buf
+		defer func() { os.Stderr = os.Stderr }()
+
+		err := runDoctor(doctorCmd, nil)
+		if err != nil {
+			t.Fatalf("runDoctor: %v", err)
+		}
+		if !bytes.Contains(buf.Bytes(), []byte("not found")) {
+			t.Errorf("stderr should warn about missing Aptfile, got: %s", buf.String())
+		}
+	})
+}

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -67,7 +67,7 @@ func TestRootCmd(t *testing.T) {
 			cmdNames[cmd.Name()] = true
 		}
 
-		expectedCommands := []string{"check", "cleanup", "dump", "install", "lock", "outdated", "sync"}
+		expectedCommands := []string{"check", "cleanup", "doctor", "dump", "install", "lock", "outdated", "sync"}
 		for _, expected := range expectedCommands {
 			if !cmdNames[expected] {
 				t.Errorf("Expected subcommand %q not found", expected)


### PR DESCRIPTION
Implements `apt-bundle doctor`:
- Aptfile validation: parse, report unknown directives and line numbers
- Environment checks: apt-get, add-apt-repository on PATH; state file readable
- `--aptfile-only`: only run Aptfile validation
- Exit non-zero if any check fails
- Tests and README updated

Made with [Cursor](https://cursor.com)