### PR TITLE
PR 6: Check strict + --json

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,10 @@ sudo apt-bundle --no-update
 # Make system match Aptfile (install missing, remove no-longer-listed)
 sudo apt-bundle sync
 
-# Check if packages are installed (no root required)
+# Check if packages/repos/keys from Aptfile are present (exit 0 only if all present)
 apt-bundle check
+# Machine-friendly output for CI
+apt-bundle check --json
 
 # Validate Aptfile and check environment (apt-get, add-apt-repository, state)
 apt-bundle doctor

--- a/internal/apt/keys.go
+++ b/internal/apt/keys.go
@@ -17,6 +17,13 @@ const (
 	KeyPrefix = "apt-bundle-"
 )
 
+// KeyPathForURL returns the path where AddGPGKey would store the key for the given URL
+func KeyPathForURL(keyURL string) string {
+	hash := sha256.Sum256([]byte(keyURL))
+	filename := fmt.Sprintf("%s%x.gpg", KeyPrefix, hash[:8])
+	return filepath.Join(KeyringDir, filename)
+}
+
 // httpGet is the function used to make HTTP requests (overridable for testing)
 var httpGet = http.Get
 

--- a/internal/commands/check.go
+++ b/internal/commands/check.go
@@ -1,35 +1,118 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"sort"
+	"strings"
 
+	"github.com/apt-bundle/apt-bundle/internal/apt"
 	"github.com/apt-bundle/apt-bundle/internal/aptfile"
 	"github.com/spf13/cobra"
 )
+
+var checkJSON bool
 
 var checkCmd = &cobra.Command{
 	Use:   "check",
 	Short: "Check if packages and repositories from Aptfile are present",
 	Long: `Read the Aptfile and check if all specified packages and repositories
-are present on the system without installing them.`,
+are present on the system. Exit 0 only if all entries are satisfied; non-zero otherwise.
+Use --json for machine-friendly output.`,
 	RunE: runCheck,
 }
 
 func init() {
 	rootCmd.AddCommand(checkCmd)
+	checkCmd.Flags().BoolVar(&checkJSON, "json", false, "Output result as JSON (ok, missing list)")
+}
+
+// CheckResult is the structure for --json output
+type CheckResult struct {
+	OK      bool     `json:"ok"`
+	Missing []string `json:"missing"`
+}
+
+// doCheck runs the check and returns ok and missing list (caller handles output and exit)
+func doCheck(aptFilePath string) (ok bool, missing []string, err error) {
+	entries, err := aptfile.Parse(aptFilePath)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to parse Aptfile: %w", err)
+	}
+
+	sources, err := apt.ListCustomSources(apt.SourcesListPath, apt.SourcesDir)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to list sources: %w", err)
+	}
+	sourceLines := make(map[string]bool)
+	for _, e := range sources {
+		sourceLines[e.AptfileLine] = true
+	}
+
+	for _, entry := range entries {
+		switch entry.Type {
+		case aptfile.EntryTypeApt:
+			pkgName := strings.SplitN(entry.Value, "=", 2)[0]
+			installed, err := apt.IsPackageInstalled(pkgName)
+			if err != nil {
+				return false, nil, fmt.Errorf("check package %s: %w", pkgName, err)
+			}
+			if !installed {
+				missing = append(missing, pkgName)
+			}
+
+		case aptfile.EntryTypePPA:
+			line := "ppa " + entry.Value
+			if !sourceLines[line] {
+				missing = append(missing, line)
+			}
+
+		case aptfile.EntryTypeDeb:
+			line := "deb " + entry.Value
+			if !sourceLines[line] {
+				missing = append(missing, line)
+			}
+
+		case aptfile.EntryTypeKey:
+			keyPath := apt.KeyPathForURL(entry.Value)
+			if _, err := os.Stat(keyPath); os.IsNotExist(err) {
+				missing = append(missing, "key "+entry.Value)
+			}
+		}
+	}
+
+	sort.Strings(missing)
+	return len(missing) == 0, missing, nil
 }
 
 func runCheck(cmd *cobra.Command, args []string) error {
-	fmt.Printf("Checking Aptfile: %s\n", aptfilePath)
-
-	entries, err := aptfile.Parse(aptfilePath)
+	ok, missing, err := doCheck(aptfilePath)
 	if err != nil {
-		return fmt.Errorf("failed to parse Aptfile: %w", err)
+		return err
 	}
 
+	if checkJSON {
+		out := CheckResult{OK: ok, Missing: missing}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(out); err != nil {
+			return err
+		}
+		if !ok {
+			os.Exit(1)
+		}
+		return nil
+	}
+
+	entries, _ := aptfile.Parse(aptfilePath)
+	fmt.Printf("Checking Aptfile: %s\n", aptfilePath)
 	fmt.Printf("Checking %d entries...\n\n", len(entries))
-
-	// TODO: Check repositories, GPG keys, packages; report missing items
-
+	if ok {
+		fmt.Println("✓ All entries present.")
+		return nil
+	}
+	fmt.Fprintf(os.Stderr, "✗ %d missing: %v\n", len(missing), missing)
+	os.Exit(1)
 	return nil
 }

--- a/internal/commands/check_test.go
+++ b/internal/commands/check_test.go
@@ -1,9 +1,15 @@
 package commands
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/apt-bundle/apt-bundle/internal/apt"
+	"github.com/apt-bundle/apt-bundle/internal/testutil"
 )
 
 func TestCheckCmd(t *testing.T) {
@@ -19,26 +25,83 @@ func TestCheckCmd(t *testing.T) {
 		if checkCmd.RunE == nil {
 			t.Error("checkCmd.RunE is nil")
 		}
+
+		if checkCmd.Flags().Lookup("json") == nil {
+			t.Error("--json flag not found")
+		}
 	})
 }
 
 func TestRunCheck(t *testing.T) {
-	t.Run("with valid aptfile", func(t *testing.T) {
+	t.Run("all present with mock", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "Aptfile")
-		content := "apt curl\napt git\n"
+		if err := os.WriteFile(tmpFile, []byte("apt curl\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		origPath := aptfilePath
+		aptfilePath = tmpFile
+		defer func() { aptfilePath = origPath }()
 
-		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
-			t.Fatalf("Failed to create temp file: %v", err)
+		mock := testutil.NewMockExecutor()
+		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
+			if name == "dpkg-query" && len(args) >= 4 && args[3] == "curl" {
+				return []byte("install ok installed"), nil
+			}
+			return nil, errors.New("unexpected command")
+		}
+		apt.SetExecutor(mock)
+		defer apt.ResetExecutor()
+
+		err := runCheck(checkCmd, nil)
+		if err != nil {
+			t.Errorf("runCheck: %v", err)
+		}
+	})
+
+	t.Run("doCheck returns missing package", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "Aptfile")
+		if err := os.WriteFile(tmpFile, []byte("apt missingpkg\n"), 0644); err != nil {
+			t.Fatal(err)
 		}
 
-		originalPath := aptfilePath
-		defer func() { aptfilePath = originalPath }()
-		aptfilePath = tmpFile
+		mock := testutil.NewMockExecutor()
+		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
+			if name == "dpkg-query" {
+				return nil, errors.New("not installed")
+			}
+			return nil, errors.New("unexpected")
+		}
+		apt.SetExecutor(mock)
+		defer apt.ResetExecutor()
 
-		err := runCheck(checkCmd, []string{})
+		ok, missing, err := doCheck(tmpFile)
 		if err != nil {
-			t.Errorf("runCheck() with valid Aptfile returned error: %v", err)
+			t.Fatalf("doCheck: %v", err)
+		}
+		if ok {
+			t.Error("expected ok=false")
+		}
+		if len(missing) != 1 || missing[0] != "missingpkg" {
+			t.Errorf("expected missing=[missingpkg], got %v", missing)
+		}
+	})
+
+	t.Run("CheckResult JSON roundtrip", func(t *testing.T) {
+		res := CheckResult{OK: false, Missing: []string{"pkg1"}}
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(res); err != nil {
+			t.Fatal(err)
+		}
+		var decoded CheckResult
+		if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+			t.Fatal(err)
+		}
+		if decoded.OK != res.OK || len(decoded.Missing) != 1 || decoded.Missing[0] != "pkg1" {
+			t.Errorf("decoded = %+v", decoded)
 		}
 	})
 


### PR DESCRIPTION
Implements full check and machine-friendly output:
- Verify each Aptfile entry: packages (IsPackageInstalled), ppa/deb (ListCustomSources), keys (KeyPathForURL + stat)
- Exit 0 only if all present; non-zero otherwise
- `--json`: output { ok, missing } for scripts/CI
- KeyPathForURL in apt/keys.go; doCheck for testability
- Tests and README updated

Made with [Cursor](https://cursor.com)