### PR TITLE
PR 7: Dry-run for install and sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,13 @@ sudo apt-bundle --file /path/to/Aptfile
 # Skip updating package lists (useful in CI/CD)
 sudo apt-bundle --no-update
 
+# See what would be installed/added without making changes
+sudo apt-bundle install --dry-run
+
 # Make system match Aptfile (install missing, remove no-longer-listed)
 sudo apt-bundle sync
+# See what would be installed/removed without making changes
+sudo apt-bundle sync --dry-run
 
 # Check if packages/repos/keys from Aptfile are present (exit 0 only if all present)
 apt-bundle check

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -12,9 +12,10 @@ import (
 )
 
 var (
-	noUpdate   bool
-	installLock bool
+	noUpdate      bool
+	installLock   bool
 	installLocked bool
+	installDryRun bool
 )
 
 var installCmd = &cobra.Command{
@@ -31,13 +32,16 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&noUpdate, "no-update", false, "Skip updating package lists before installing")
 	installCmd.Flags().BoolVar(&installLock, "lock", false, "After install, write Aptfile.lock with current package versions")
 	installCmd.Flags().BoolVar(&installLocked, "locked", false, "Install only versions from Aptfile.lock (fail if lock missing)")
+	installCmd.Flags().BoolVar(&installDryRun, "dry-run", false, "Only report what would be installed/added; do not run apt or change state")
 	rootCmd.AddCommand(installCmd)
 	rootCmd.RunE = runInstall
 }
 
 func runInstall(cmd *cobra.Command, args []string) error {
-	if err := checkRoot(); err != nil {
-		return err
+	if !installDryRun {
+		if err := checkRoot(); err != nil {
+			return err
+		}
 	}
 
 	fmt.Printf("Reading Aptfile from: %s\n", aptfilePath)
@@ -48,6 +52,10 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Found %d entries in Aptfile\n", len(entries))
+
+	if installDryRun {
+		return runInstallDryRun(entries)
+	}
 
 	state, err := apt.LoadState()
 	if err != nil {
@@ -179,4 +187,64 @@ func writeLockFileFromPackages(packages []string) error {
 		lines = append(lines, pv.pkg+"="+pv.ver)
 	}
 	return os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0644)
+}
+
+func runInstallDryRun(entries []aptfile.Entry) error {
+	sources, err := apt.ListCustomSources(apt.SourcesListPath, apt.SourcesDir)
+	if err != nil {
+		return fmt.Errorf("failed to list sources: %w", err)
+	}
+	sourceLines := make(map[string]bool)
+	for _, e := range sources {
+		sourceLines[e.AptfileLine] = true
+	}
+
+	var wouldAddKeys, wouldAddRepos, wouldInstall []string
+	for _, entry := range entries {
+		switch entry.Type {
+		case aptfile.EntryTypeKey:
+			keyPath := apt.KeyPathForURL(entry.Value)
+			if _, err := os.Stat(keyPath); os.IsNotExist(err) {
+				wouldAddKeys = append(wouldAddKeys, entry.Value)
+			}
+		case aptfile.EntryTypePPA:
+			line := "ppa " + entry.Value
+			if !sourceLines[line] {
+				wouldAddRepos = append(wouldAddRepos, line)
+			}
+		case aptfile.EntryTypeDeb:
+			line := "deb " + entry.Value
+			if !sourceLines[line] {
+				wouldAddRepos = append(wouldAddRepos, line)
+			}
+		case aptfile.EntryTypeApt:
+			pkgName := strings.SplitN(entry.Value, "=", 2)[0]
+			installed, _ := apt.IsPackageInstalled(pkgName)
+			if !installed {
+				wouldInstall = append(wouldInstall, entry.Value)
+			}
+		}
+	}
+
+	fmt.Println("--- dry-run: would perform the following ---")
+	if len(wouldAddKeys) > 0 {
+		for _, u := range wouldAddKeys {
+			fmt.Printf("Would add key: %s\n", u)
+		}
+	}
+	if len(wouldAddRepos) > 0 {
+		for _, r := range wouldAddRepos {
+			fmt.Printf("Would add repository: %s\n", r)
+		}
+	}
+	if len(wouldInstall) > 0 {
+		fmt.Printf("Would run apt-get update (if repos added)\n")
+		for _, p := range wouldInstall {
+			fmt.Printf("Would install: %s\n", p)
+		}
+	}
+	if len(wouldAddKeys) == 0 && len(wouldAddRepos) == 0 && len(wouldInstall) == 0 {
+		fmt.Println("Nothing to do; all entries already present.")
+	}
+	return nil
 }

--- a/internal/commands/install_test.go
+++ b/internal/commands/install_test.go
@@ -125,6 +125,40 @@ func setupMockRoot() func() {
 	}
 }
 
+func TestRunInstallDryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "Aptfile")
+	if err := os.WriteFile(tmpFile, []byte("apt curl\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	origPath := aptfilePath
+	aptfilePath = tmpFile
+	defer func() { aptfilePath = origPath }()
+
+	mock := testutil.NewMockExecutor()
+	mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
+		if name == "dpkg-query" {
+			return nil, errors.New("not installed")
+		}
+		return nil, errors.New("unexpected")
+	}
+	apt.SetExecutor(mock)
+	defer apt.ResetExecutor()
+
+	installDryRun = true
+	defer func() { installDryRun = false }()
+	SetGetEuid(func() int { return 0 })
+	defer ResetGetEuid()
+
+	err := runInstall(installCmd, nil)
+	if err != nil {
+		t.Fatalf("runInstall dry-run: %v", err)
+	}
+	if len(mock.RunCalls) != 0 {
+		t.Errorf("dry-run should not run any commands (apt-get, add-apt-repository, etc.); got %d Run calls", len(mock.RunCalls))
+	}
+}
+
 func TestRunInstallWithMock(t *testing.T) {
 	t.Run("nonexistent aptfile", func(t *testing.T) {
 		cleanup := setupMockRoot()

--- a/internal/commands/sync.go
+++ b/internal/commands/sync.go
@@ -1,10 +1,16 @@
 package commands
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/apt-bundle/apt-bundle/internal/apt"
+	"github.com/apt-bundle/apt-bundle/internal/aptfile"
 	"github.com/spf13/cobra"
 )
 
 var syncAutoremove bool
+var syncDryRun bool
 
 var syncCmd = &cobra.Command{
 	Use:   "sync",
@@ -21,12 +27,19 @@ declared Aptfile.`,
 
 func init() {
 	syncCmd.Flags().BoolVar(&syncAutoremove, "autoremove", false, "Run apt autoremove after cleanup")
+	syncCmd.Flags().BoolVar(&syncDryRun, "dry-run", false, "Only report what would be installed and removed; no apt or state changes")
 	rootCmd.AddCommand(syncCmd)
 }
 
 func runSync(cmd *cobra.Command, args []string) error {
-	if err := checkRoot(); err != nil {
-		return err
+	if !syncDryRun {
+		if err := checkRoot(); err != nil {
+			return err
+		}
+	}
+
+	if syncDryRun {
+		return runSyncDryRun()
 	}
 
 	if err := runInstall(cmd, args); err != nil {
@@ -43,4 +56,62 @@ func runSync(cmd *cobra.Command, args []string) error {
 		cleanupAutoremove = origAutoremove
 	}()
 	return runCleanup(cmd, args)
+}
+
+func runSyncDryRun() error {
+	entries, err := aptfile.Parse(aptfilePath)
+	if err != nil {
+		return fmt.Errorf("failed to parse Aptfile: %w", err)
+	}
+
+	// What would install do
+	fmt.Printf("Reading Aptfile from: %s (dry-run)\n", aptfilePath)
+	wouldInstall, wouldRemove := syncDryRunPlan(entries)
+	if len(wouldInstall) > 0 {
+		fmt.Println("--- would install ---")
+		for _, p := range wouldInstall {
+			fmt.Printf("  %s\n", p)
+		}
+	}
+	if len(wouldRemove) > 0 {
+		fmt.Println("--- would remove ---")
+		for _, p := range wouldRemove {
+			fmt.Printf("  %s\n", p)
+		}
+	}
+	if len(wouldInstall) == 0 && len(wouldRemove) == 0 {
+		fmt.Println("Nothing to do; system matches Aptfile.")
+	}
+	return nil
+}
+
+// syncDryRunPlan returns packages that would be installed and that would be removed
+func syncDryRunPlan(entries []aptfile.Entry) (wouldInstall, wouldRemove []string) {
+	state, err := apt.LoadState()
+	if err != nil {
+		return nil, nil
+	}
+	sources, err := apt.ListCustomSources(apt.SourcesListPath, apt.SourcesDir)
+	if err != nil {
+		return nil, nil
+	}
+	sourceLines := make(map[string]bool)
+	for _, e := range sources {
+		sourceLines[e.AptfileLine] = true
+	}
+
+	var aptfilePackages []string
+	for _, entry := range entries {
+		if entry.Type != aptfile.EntryTypeApt {
+			continue
+		}
+		pkgName := strings.SplitN(entry.Value, "=", 2)[0]
+		aptfilePackages = append(aptfilePackages, pkgName)
+		installed, _ := apt.IsPackageInstalled(pkgName)
+		if !installed {
+			wouldInstall = append(wouldInstall, entry.Value)
+		}
+	}
+	wouldRemove = state.GetPackagesNotIn(aptfilePackages)
+	return wouldInstall, wouldRemove
 }

--- a/internal/commands/sync_test.go
+++ b/internal/commands/sync_test.go
@@ -32,7 +32,45 @@ func TestSyncCmd(t *testing.T) {
 		} else if autoremoveFlag.DefValue != "false" {
 			t.Errorf("--autoremove default = %v, want 'false'", autoremoveFlag.DefValue)
 		}
+		if syncCmd.Flags().Lookup("dry-run") == nil {
+			t.Error("--dry-run flag not found")
+		}
 	})
+}
+
+func TestRunSyncDryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "Aptfile")
+	if err := os.WriteFile(tmpFile, []byte("apt curl\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	origPath := aptfilePath
+	aptfilePath = tmpFile
+	defer func() { aptfilePath = origPath }()
+
+	apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
+	defer apt.ResetStatePath()
+
+	mock := testutil.NewMockExecutor()
+	mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
+		if name == "dpkg-query" {
+			return nil, errors.New("not installed")
+		}
+		return nil, errors.New("unexpected")
+	}
+	apt.SetExecutor(mock)
+	defer apt.ResetExecutor()
+
+	syncDryRun = true
+	defer func() { syncDryRun = false }()
+
+	err := runSync(syncCmd, nil)
+	if err != nil {
+		t.Fatalf("runSync dry-run: %v", err)
+	}
+	if len(mock.RunCalls) != 0 {
+		t.Errorf("sync dry-run should not run apt/install/cleanup; got %d Run calls", len(mock.RunCalls))
+	}
 }
 
 func TestRunSyncWithMock(t *testing.T) {


### PR DESCRIPTION
Adds `--dry-run` to install and sync:
- **install --dry-run**: list keys, repos, and packages that would be added; no apt-get, add-apt-repository, or state changes
- **sync --dry-run**: list packages that would be installed and removed; no apt or state changes
- Tests assert no Run calls when dry-run; README updated

Made with [Cursor](https://cursor.com)