### PR TITLE
chore: add Cursor rules for Go/apt-bundle coding standards

### DIFF
--- a/.cursor/rules/go-apt-bundle-standards.mdc
+++ b/.cursor/rules/go-apt-bundle-standards.mdc
@@ -1,0 +1,89 @@
+---
+description: Go coding standards for apt-bundle to prevent common bugs and maintain consistency
+globs: "**/*.go"
+alwaysApply: false
+---
+
+# Go / apt-bundle Coding Standards
+
+Guidelines derived from code review to prevent recurring issues.
+
+## Use Type Constants Over String Literals
+
+When comparing to known types (e.g. `EntryType`), use the constant to avoid typos and stay consistent.
+
+```go
+// ❌ BAD
+if entry.Type == "apt" { ... }
+
+// ✅ GOOD
+if entry.Type == aptfile.EntryTypeApt { ... }
+```
+
+## Check Before Mutate (Prefix/Trim Logic)
+
+When parsing or trimming strings, check the condition **before** trimming. Trimming first can make the subsequent check always false.
+
+```go
+// ❌ BAD - HasPrefix is false after TrimPrefix
+line = strings.TrimPrefix(line, "deb-src ")
+if strings.HasPrefix(line, "deb-src ") { ... }
+
+// ✅ GOOD - Check first, then trim
+if strings.HasPrefix(line, "deb-src ") {
+    line = strings.TrimPrefix(line, "deb-src ")
+} else if strings.HasPrefix(line, "deb ") {
+    line = strings.TrimPrefix(line, "deb ")
+}
+```
+
+## Prefer Returning Errors Over os.Exit
+
+In Cobra command handlers, return errors and let `main` handle exit codes. `os.Exit` bypasses `defer` and is harder to test.
+
+```go
+// ❌ BAD
+if !ok {
+    os.Exit(1)
+}
+return nil
+
+// ✅ GOOD
+if !ok {
+    return fmt.Errorf("validation failed")
+}
+return nil
+```
+
+## Avoid Redundant Parsing or I/O
+
+Don't parse or read the same file/data twice when you can pass results through. Refactor to return or accept the parsed data.
+
+```go
+// ❌ BAD - parses Aptfile twice
+ok, missing, _ := doCheck(aptfilePath)
+entries, _ := aptfile.Parse(aptfilePath)
+fmt.Printf("Checking %d entries...\n", len(entries))
+
+// ✅ GOOD - parse once, pass through
+entries, _ := aptfile.Parse(aptfilePath)
+ok, missing, _ := doCheckWithEntries(entries)
+fmt.Printf("Checking %d entries...\n", len(entries))
+```
+
+## HTTP Clients: Use Timeouts
+
+External HTTP requests (e.g. downloading GPG keys) should use a client with a timeout to avoid hanging.
+
+```go
+// ❌ BAD - no timeout
+resp, err := http.Get(url)
+
+// ✅ GOOD
+client := &http.Client{Timeout: 30 * time.Second}
+resp, err := client.Get(url)
+```
+
+## Dependency Injection for Testability
+
+External system calls (exec, HTTP, filesystem) should be overridable via package-level vars or interfaces. Use `SetX`/`ResetX` for tests and `defer ResetX()` in tests.


### PR DESCRIPTION
Add `.cursor/rules/go-apt-bundle-standards.mdc` with guidelines derived from expert code review to prevent recurring issues:

- **Use type constants over string literals** — avoid typos, stay consistent
- **Check before mutate (prefix/trim logic)** — prevents logic bugs like parseDebLine deb-src
- **Prefer returning errors over os.Exit** — Cobra-friendly, defer-safe
- **Avoid redundant parsing or I/O** — parse once, pass through
- **HTTP clients: use timeouts** — avoid hanging on external requests
- **Dependency injection for testability** — SetX/ResetX pattern

These rules apply when working with Go files (`**/*.go`).

Made with [Cursor](https://cursor.com)