### PR TITLE
fix: address expert code review findings

### DIFF
--- a/internal/apt/keys.go
+++ b/internal/apt/keys.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const (
@@ -24,8 +25,11 @@ func KeyPathForURL(keyURL string) string {
 	return filepath.Join(KeyringDir, filename)
 }
 
+// keyHTTPClient is used for key downloads; has timeout to avoid hanging
+var keyHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
 // httpGet is the function used to make HTTP requests (overridable for testing)
-var httpGet = http.Get
+var httpGet = keyHTTPClient.Get
 
 // AddGPGKey downloads and adds a GPG key from a URL
 // Returns the path to the saved key file for use with Signed-By in DEB822 format
@@ -133,5 +137,5 @@ func SetHTTPGet(f func(string) (*http.Response, error)) {
 
 // ResetHTTPGet resets the HTTP get function to default (for testing only)
 func ResetHTTPGet() {
-	httpGet = http.Get
+	httpGet = keyHTTPClient.Get
 }

--- a/internal/apt/repositories.go
+++ b/internal/apt/repositories.go
@@ -130,13 +130,13 @@ func parseDebLine(line string) (*DebRepository, error) {
 		Types: "deb",
 	}
 
-	// Remove leading "deb " or "deb-src " if present
-	line = strings.TrimPrefix(line, "deb-src ")
+	// Remove leading "deb " or "deb-src " if present (check before trim)
 	if strings.HasPrefix(line, "deb-src ") {
 		repo.Types = "deb-src"
 		line = strings.TrimPrefix(line, "deb-src ")
+	} else if strings.HasPrefix(line, "deb ") {
+		line = strings.TrimPrefix(line, "deb ")
 	}
-	line = strings.TrimPrefix(line, "deb ")
 
 	// Extract options in brackets [key=value key2=value2]
 	optionsRegex := regexp.MustCompile(`^\[([^\]]+)\]\s*`)

--- a/internal/apt/repositories_test.go
+++ b/internal/apt/repositories_test.go
@@ -165,6 +165,19 @@ func TestParseDebLine(t *testing.T) {
 		}
 	})
 
+	t.Run("deb-src line", func(t *testing.T) {
+		repo, err := parseDebLine("deb-src https://example.com/ubuntu jammy main")
+		if err != nil {
+			t.Fatalf("parseDebLine failed: %v", err)
+		}
+		if repo.Types != "deb-src" {
+			t.Errorf("Expected type 'deb-src', got '%s'", repo.Types)
+		}
+		if repo.URIs != "https://example.com/ubuntu" {
+			t.Errorf("Expected URI 'https://example.com/ubuntu', got '%s'", repo.URIs)
+		}
+	})
+
 	t.Run("invalid deb line - too few parts", func(t *testing.T) {
 		_, err := parseDebLine("https://example.com/ubuntu")
 		if err == nil {

--- a/internal/commands/check.go
+++ b/internal/commands/check.go
@@ -34,16 +34,16 @@ type CheckResult struct {
 	Missing []string `json:"missing"`
 }
 
-// doCheck runs the check and returns ok and missing list (caller handles output and exit)
-func doCheck(aptFilePath string) (ok bool, missing []string, err error) {
-	entries, err := aptfile.Parse(aptFilePath)
+// doCheck runs the check and returns ok, missing list, and entries (parse once).
+func doCheck(aptFilePath string) (ok bool, missing []string, entries []aptfile.Entry, err error) {
+	entries, err = aptfile.Parse(aptFilePath)
 	if err != nil {
-		return false, nil, fmt.Errorf("failed to parse Aptfile: %w", err)
+		return false, nil, nil, fmt.Errorf("failed to parse Aptfile: %w", err)
 	}
 
 	sources, err := apt.ListCustomSources(apt.SourcesListPath, apt.SourcesDir)
 	if err != nil {
-		return false, nil, fmt.Errorf("failed to list sources: %w", err)
+		return false, nil, nil, fmt.Errorf("failed to list sources: %w", err)
 	}
 	sourceLines := make(map[string]bool)
 	for _, e := range sources {
@@ -56,7 +56,7 @@ func doCheck(aptFilePath string) (ok bool, missing []string, err error) {
 			pkgName := strings.SplitN(entry.Value, "=", 2)[0]
 			installed, err := apt.IsPackageInstalled(pkgName)
 			if err != nil {
-				return false, nil, fmt.Errorf("check package %s: %w", pkgName, err)
+				return false, nil, nil, fmt.Errorf("check package %s: %w", pkgName, err)
 			}
 			if !installed {
 				missing = append(missing, pkgName)
@@ -83,11 +83,11 @@ func doCheck(aptFilePath string) (ok bool, missing []string, err error) {
 	}
 
 	sort.Strings(missing)
-	return len(missing) == 0, missing, nil
+	return len(missing) == 0, missing, entries, nil
 }
 
 func runCheck(cmd *cobra.Command, args []string) error {
-	ok, missing, err := doCheck(aptfilePath)
+	ok, missing, entries, err := doCheck(aptfilePath)
 	if err != nil {
 		return err
 	}
@@ -100,19 +100,16 @@ func runCheck(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if !ok {
-			os.Exit(1)
+			return fmt.Errorf("%d entries missing", len(missing))
 		}
 		return nil
 	}
 
-	entries, _ := aptfile.Parse(aptfilePath)
 	fmt.Printf("Checking Aptfile: %s\n", aptfilePath)
 	fmt.Printf("Checking %d entries...\n\n", len(entries))
 	if ok {
 		fmt.Println("✓ All entries present.")
 		return nil
 	}
-	fmt.Fprintf(os.Stderr, "✗ %d missing: %v\n", len(missing), missing)
-	os.Exit(1)
-	return nil
+	return fmt.Errorf("%d missing: %v", len(missing), missing)
 }

--- a/internal/commands/check_test.go
+++ b/internal/commands/check_test.go
@@ -77,7 +77,7 @@ func TestRunCheck(t *testing.T) {
 		apt.SetExecutor(mock)
 		defer apt.ResetExecutor()
 
-		ok, missing, err := doCheck(tmpFile)
+		ok, missing, _, err := doCheck(tmpFile)
 		if err != nil {
 			t.Fatalf("doCheck: %v", err)
 		}

--- a/internal/commands/cleanup.go
+++ b/internal/commands/cleanup.go
@@ -57,7 +57,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	// Get packages from Aptfile
 	aptfilePackages := []string{}
 	for _, entry := range entries {
-		if entry.Type == "apt" {
+		if entry.Type == aptfile.EntryTypeApt {
 			aptfilePackages = append(aptfilePackages, entry.Value)
 		}
 	}

--- a/internal/commands/doctor.go
+++ b/internal/commands/doctor.go
@@ -45,7 +45,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 
 	if doctorAptfileOnly {
 		if failed {
-			os.Exit(1)
+			return fmt.Errorf("Aptfile validation failed")
 		}
 		return nil
 	}
@@ -73,7 +73,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	}
 
 	if failed {
-		os.Exit(1)
+		return fmt.Errorf("environment check failed")
 	}
 	return nil
 }

--- a/internal/commands/outdated.go
+++ b/internal/commands/outdated.go
@@ -97,6 +97,5 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 	for _, e := range outdated {
 		fmt.Printf("%s (installed: %s, available: %s)\n", e.Name, e.Installed, e.Candidate)
 	}
-	os.Exit(1)
-	return nil
+	return fmt.Errorf("%d package(s) have upgrades available", len(outdated))
 }


### PR DESCRIPTION
Addresses findings from the expert code review (14 Feb 2026):

- **parseDebLine deb-src bug** — Check prefix before trim in \`repositories.go\`; \`deb-src\` lines were incorrectly parsed as \`deb\`
- **Use aptfile.EntryTypeApt** — Replace string literal in \`cleanup.go\` for consistency
- **Avoid redundant Aptfile parse** — \`doCheck\` now returns entries; parse once in \`check.go\`
- **Replace os.Exit with return errors** — \`check.go\`, \`doctor.go\`, \`outdated.go\`; Cobra-friendly, defer-safe
- **HTTP timeout for key downloads** — 30s timeout in \`keys.go\` to avoid hanging
- **Test for deb-src** — Add \`TestParseDebLine\` case for \`deb-src\` lines