### PR TITLE
fix: address round 2 code review findings

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,6 +10,33 @@ if ! git diff --cached --name-only | grep -q '\.go$'; then
   exit 0
 fi
 
+# Ensure go is available: try direnv first, then common PATH locations.
+# Git hooks often run with minimal PATH (e.g. from IDE), so we need to find go.
+ensure_go() {
+  if command -v go >/dev/null 2>&1; then
+    return 0
+  fi
+  # Try direnv (loads .envrc if present)
+  if command -v direnv >/dev/null 2>&1; then
+    eval "$(direnv export sh 2>/dev/null)" || true
+    if command -v go >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+  # Fallback: add common Go install locations to PATH
+  export PATH="/usr/local/go/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+  if command -v go >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "Error: 'go' not found. Pre-commit checks require Go."
+  echo "  - Run 'git commit' from a terminal where 'go' is in PATH, or"
+  echo "  - Use direnv with a .envrc that adds Go to PATH, or"
+  echo "  - Install Go to /usr/local/go or ensure it's in your PATH."
+  echo "  - To skip checks: git commit --no-verify"
+  exit 1
+}
+ensure_go
+
 echo "Running pre-commit checks..."
 
 # 1. Autofix (formatting, imports)

--- a/internal/apt/keys.go
+++ b/internal/apt/keys.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const (
@@ -24,8 +25,11 @@ func KeyPathForURL(keyURL string) string {
 	return filepath.Join(KeyringDir, filename)
 }
 
+// keyHTTPClient is used for key downloads; has timeout to avoid hanging
+var keyHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
 // httpGet is the function used to make HTTP requests (overridable for testing)
-var httpGet = http.Get
+var httpGet = keyHTTPClient.Get
 
 // AddGPGKey downloads and adds a GPG key from a URL
 // Returns the path to the saved key file for use with Signed-By in DEB822 format
@@ -133,5 +137,5 @@ func SetHTTPGet(f func(string) (*http.Response, error)) {
 
 // ResetHTTPGet resets the HTTP get function to default (for testing only)
 func ResetHTTPGet() {
-	httpGet = http.Get
+	httpGet = keyHTTPClient.Get
 }

--- a/internal/apt/repositories.go
+++ b/internal/apt/repositories.go
@@ -130,13 +130,13 @@ func parseDebLine(line string) (*DebRepository, error) {
 		Types: "deb",
 	}
 
-	// Remove leading "deb " or "deb-src " if present
-	line = strings.TrimPrefix(line, "deb-src ")
+	// Remove leading "deb " or "deb-src " if present (check before trim)
 	if strings.HasPrefix(line, "deb-src ") {
 		repo.Types = "deb-src"
 		line = strings.TrimPrefix(line, "deb-src ")
+	} else if strings.HasPrefix(line, "deb ") {
+		line = strings.TrimPrefix(line, "deb ")
 	}
-	line = strings.TrimPrefix(line, "deb ")
 
 	// Extract options in brackets [key=value key2=value2]
 	optionsRegex := regexp.MustCompile(`^\[([^\]]+)\]\s*`)

--- a/internal/apt/repositories_test.go
+++ b/internal/apt/repositories_test.go
@@ -165,6 +165,19 @@ func TestParseDebLine(t *testing.T) {
 		}
 	})
 
+	t.Run("deb-src line", func(t *testing.T) {
+		repo, err := parseDebLine("deb-src https://example.com/ubuntu jammy main")
+		if err != nil {
+			t.Fatalf("parseDebLine failed: %v", err)
+		}
+		if repo.Types != "deb-src" {
+			t.Errorf("Expected type 'deb-src', got '%s'", repo.Types)
+		}
+		if repo.URIs != "https://example.com/ubuntu" {
+			t.Errorf("Expected URI 'https://example.com/ubuntu', got '%s'", repo.URIs)
+		}
+	})
+
 	t.Run("invalid deb line - too few parts", func(t *testing.T) {
 		_, err := parseDebLine("https://example.com/ubuntu")
 		if err == nil {

--- a/internal/commands/check.go
+++ b/internal/commands/check.go
@@ -34,16 +34,16 @@ type CheckResult struct {
 	Missing []string `json:"missing"`
 }
 
-// doCheck runs the check and returns ok and missing list (caller handles output and exit)
-func doCheck(aptFilePath string) (ok bool, missing []string, err error) {
-	entries, err := aptfile.Parse(aptFilePath)
+// doCheck runs the check and returns ok, missing list, and entries (parse once).
+func doCheck(aptFilePath string) (ok bool, missing []string, entries []aptfile.Entry, err error) {
+	entries, err = aptfile.Parse(aptFilePath)
 	if err != nil {
-		return false, nil, fmt.Errorf("failed to parse Aptfile: %w", err)
+		return false, nil, nil, fmt.Errorf("failed to parse Aptfile: %w", err)
 	}
 
 	sources, err := apt.ListCustomSources(apt.SourcesListPath, apt.SourcesDir)
 	if err != nil {
-		return false, nil, fmt.Errorf("failed to list sources: %w", err)
+		return false, nil, nil, fmt.Errorf("failed to list sources: %w", err)
 	}
 	sourceLines := make(map[string]bool)
 	for _, e := range sources {
@@ -56,7 +56,7 @@ func doCheck(aptFilePath string) (ok bool, missing []string, err error) {
 			pkgName := strings.SplitN(entry.Value, "=", 2)[0]
 			installed, err := apt.IsPackageInstalled(pkgName)
 			if err != nil {
-				return false, nil, fmt.Errorf("check package %s: %w", pkgName, err)
+				return false, nil, nil, fmt.Errorf("check package %s: %w", pkgName, err)
 			}
 			if !installed {
 				missing = append(missing, pkgName)
@@ -83,11 +83,11 @@ func doCheck(aptFilePath string) (ok bool, missing []string, err error) {
 	}
 
 	sort.Strings(missing)
-	return len(missing) == 0, missing, nil
+	return len(missing) == 0, missing, entries, nil
 }
 
 func runCheck(cmd *cobra.Command, args []string) error {
-	ok, missing, err := doCheck(aptfilePath)
+	ok, missing, entries, err := doCheck(aptfilePath)
 	if err != nil {
 		return err
 	}
@@ -100,19 +100,16 @@ func runCheck(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if !ok {
-			os.Exit(1)
+			return fmt.Errorf("%d entries missing", len(missing))
 		}
 		return nil
 	}
 
-	entries, _ := aptfile.Parse(aptfilePath)
 	fmt.Printf("Checking Aptfile: %s\n", aptfilePath)
 	fmt.Printf("Checking %d entries...\n\n", len(entries))
 	if ok {
 		fmt.Println("✓ All entries present.")
 		return nil
 	}
-	fmt.Fprintf(os.Stderr, "✗ %d missing: %v\n", len(missing), missing)
-	os.Exit(1)
-	return nil
+	return fmt.Errorf("%d missing: %v", len(missing), missing)
 }

--- a/internal/commands/check_test.go
+++ b/internal/commands/check_test.go
@@ -77,7 +77,7 @@ func TestRunCheck(t *testing.T) {
 		apt.SetExecutor(mock)
 		defer apt.ResetExecutor()
 
-		ok, missing, err := doCheck(tmpFile)
+		ok, missing, _, err := doCheck(tmpFile)
 		if err != nil {
 			t.Fatalf("doCheck: %v", err)
 		}

--- a/internal/commands/cleanup.go
+++ b/internal/commands/cleanup.go
@@ -57,7 +57,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	// Get packages from Aptfile
 	aptfilePackages := []string{}
 	for _, entry := range entries {
-		if entry.Type == "apt" {
+		if entry.Type == aptfile.EntryTypeApt {
 			aptfilePackages = append(aptfilePackages, entry.Value)
 		}
 	}

--- a/internal/commands/cleanup.go
+++ b/internal/commands/cleanup.go
@@ -54,13 +54,8 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to parse Aptfile: %w", err)
 	}
 
-	// Get packages from Aptfile
-	aptfilePackages := []string{}
-	for _, entry := range entries {
-		if entry.Type == aptfile.EntryTypeApt {
-			aptfilePackages = append(aptfilePackages, entry.Value)
-		}
-	}
+	// Get package names from Aptfile (strip version for comparison with state/apt-mark)
+	aptfilePackages := extractPackageNames(entries)
 
 	var packagesToRemove []string
 
@@ -148,6 +143,23 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// extractPackageNames returns deduplicated package names from apt entries (strips version specs)
+func extractPackageNames(entries []aptfile.Entry) []string {
+	seen := make(map[string]bool)
+	var names []string
+	for _, entry := range entries {
+		if entry.Type != aptfile.EntryTypeApt {
+			continue
+		}
+		pkgName := strings.SplitN(entry.Value, "=", 2)[0]
+		if !seen[pkgName] {
+			seen[pkgName] = true
+			names = append(names, pkgName)
+		}
+	}
+	return names
 }
 
 // getPackagesToCleanup returns packages that were installed by apt-bundle but are no longer in Aptfile

--- a/internal/commands/cleanup_test.go
+++ b/internal/commands/cleanup_test.go
@@ -6,8 +6,72 @@ import (
 	"testing"
 
 	"github.com/apt-bundle/apt-bundle/internal/apt"
+	"github.com/apt-bundle/apt-bundle/internal/aptfile"
 	"github.com/apt-bundle/apt-bundle/internal/testutil"
 )
+
+func TestExtractPackageNames(t *testing.T) {
+	t.Run("strips version and deduplicates", func(t *testing.T) {
+		entries := []aptfile.Entry{
+			{Type: aptfile.EntryTypeApt, Value: "nano=2.9.3-2"},
+			{Type: aptfile.EntryTypeApt, Value: "curl"},
+			{Type: aptfile.EntryTypeApt, Value: "nano"}, // duplicate
+		}
+		names := extractPackageNames(entries)
+		if len(names) != 2 {
+			t.Errorf("expected 2 names (nano, curl), got %d: %v", len(names), names)
+		}
+		hasNano, hasCurl := false, false
+		for _, n := range names {
+			if n == "nano" {
+				hasNano = true
+			}
+			if n == "curl" {
+				hasCurl = true
+			}
+		}
+		if !hasNano || !hasCurl {
+			t.Errorf("expected nano and curl, got %v", names)
+		}
+	})
+	t.Run("version-pinned package not removed", func(t *testing.T) {
+		// State has "nano"; Aptfile has "apt nano=2.9.3-2". Should NOT remove nano.
+		cleanup := setupMockRoot()
+		defer cleanup()
+
+		apt.SetExecutor(testutil.NewMockExecutor())
+		defer apt.ResetExecutor()
+
+		tmpDir := t.TempDir()
+		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
+		defer apt.ResetStatePath()
+
+		state := apt.NewState()
+		state.AddPackage("nano")
+		if err := state.Save(); err != nil {
+			t.Fatalf("Failed to save state: %v", err)
+		}
+
+		tmpFile := filepath.Join(tmpDir, "Aptfile")
+		if err := os.WriteFile(tmpFile, []byte("apt \"nano=2.9.3-2\"\n"), 0644); err != nil {
+			t.Fatalf("Failed to create Aptfile: %v", err)
+		}
+
+		origPath := aptfilePath
+		aptfilePath = tmpFile
+		defer func() { aptfilePath = origPath }()
+
+		cleanupForce = false
+		cleanupZap = false
+		defer func() { cleanupForce = false; cleanupZap = false }()
+
+		err := runCleanup(cleanupCmd, []string{})
+		if err != nil {
+			t.Errorf("runCleanup: %v", err)
+		}
+		// Should print "Nothing to clean up" - nano is in Aptfile (as version-pinned)
+	})
+}
 
 func TestCleanupCmd(t *testing.T) {
 	t.Run("cleanup command exists", func(t *testing.T) {

--- a/internal/commands/doctor.go
+++ b/internal/commands/doctor.go
@@ -45,7 +45,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 
 	if doctorAptfileOnly {
 		if failed {
-			os.Exit(1)
+			return fmt.Errorf("Aptfile validation failed")
 		}
 		return nil
 	}
@@ -73,7 +73,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	}
 
 	if failed {
-		os.Exit(1)
+		return fmt.Errorf("environment check failed")
 	}
 	return nil
 }

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -87,7 +87,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("failed to add repository: %w", err)
 			}
 			state.AddRepository(sourcePath)
-			pendingKeyPath = ""
+			// Keep pendingKeyPath for subsequent deb/deb-src lines from same repo
 			reposAdded = true
 		}
 	}

--- a/internal/commands/lock.go
+++ b/internal/commands/lock.go
@@ -97,7 +97,8 @@ func ReadLockFile() ([]string, error) {
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		if strings.Contains(line, "=") {
+		// Require "pkg=version" with both parts non-empty
+		if pkg, ver, ok := strings.Cut(line, "="); ok && pkg != "" && ver != "" {
 			specs = append(specs, line)
 		}
 	}

--- a/internal/commands/lock_test.go
+++ b/internal/commands/lock_test.go
@@ -50,4 +50,23 @@ func TestReadLockFile(t *testing.T) {
 			t.Errorf("expected 2 specs, got %d", len(specs))
 		}
 	})
+	t.Run("rejects malformed lines", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "Aptfile.lock"), []byte("valid=1.0\n=1.0\npkg=\n# comment\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		orig := aptfilePath
+		defer func() { aptfilePath = orig }()
+		aptfilePath = filepath.Join(dir, "Aptfile")
+		if err := os.WriteFile(aptfilePath, []byte("apt valid\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		specs, err := ReadLockFile()
+		if err != nil {
+			t.Fatalf("ReadLockFile: %v", err)
+		}
+		if len(specs) != 1 || specs[0] != "valid=1.0" {
+			t.Errorf("expected [valid=1.0], got %v", specs)
+		}
+	})
 }

--- a/internal/commands/outdated.go
+++ b/internal/commands/outdated.go
@@ -97,6 +97,5 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 	for _, e := range outdated {
 		fmt.Printf("%s (installed: %s, available: %s)\n", e.Name, e.Installed, e.Candidate)
 	}
-	os.Exit(1)
-	return nil
+	return fmt.Errorf("%d package(s) have upgrades available", len(outdated))
 }

--- a/internal/commands/sync.go
+++ b/internal/commands/sync.go
@@ -66,7 +66,10 @@ func runSyncDryRun() error {
 
 	// What would install do
 	fmt.Printf("Reading Aptfile from: %s (dry-run)\n", aptfilePath)
-	wouldInstall, wouldRemove := syncDryRunPlan(entries)
+	wouldInstall, wouldRemove, err := syncDryRunPlan(entries)
+	if err != nil {
+		return fmt.Errorf("sync dry-run: %w", err)
+	}
 	if len(wouldInstall) > 0 {
 		fmt.Println("--- would install ---")
 		for _, p := range wouldInstall {
@@ -86,32 +89,31 @@ func runSyncDryRun() error {
 }
 
 // syncDryRunPlan returns packages that would be installed and that would be removed
-func syncDryRunPlan(entries []aptfile.Entry) (wouldInstall, wouldRemove []string) {
+func syncDryRunPlan(entries []aptfile.Entry) (wouldInstall, wouldRemove []string, err error) {
 	state, err := apt.LoadState()
 	if err != nil {
-		return nil, nil
+		return nil, nil, fmt.Errorf("load state: %w", err)
 	}
 	sources, err := apt.ListCustomSources(apt.SourcesListPath, apt.SourcesDir)
 	if err != nil {
-		return nil, nil
+		return nil, nil, fmt.Errorf("list sources: %w", err)
 	}
 	sourceLines := make(map[string]bool)
 	for _, e := range sources {
 		sourceLines[e.AptfileLine] = true
 	}
 
-	var aptfilePackages []string
+	aptfilePackages := extractPackageNames(entries)
 	for _, entry := range entries {
 		if entry.Type != aptfile.EntryTypeApt {
 			continue
 		}
 		pkgName := strings.SplitN(entry.Value, "=", 2)[0]
-		aptfilePackages = append(aptfilePackages, pkgName)
 		installed, _ := apt.IsPackageInstalled(pkgName)
 		if !installed {
 			wouldInstall = append(wouldInstall, entry.Value)
 		}
 	}
 	wouldRemove = state.GetPackagesNotIn(aptfilePackages)
-	return wouldInstall, wouldRemove
+	return wouldInstall, wouldRemove, nil
 }


### PR DESCRIPTION
Addresses findings from the second expert code review (14 Feb 2026):

## Critical
- **Cleanup/zap version-pinned packages bug** — Normalize `aptfilePackages` to package names (strip version) so `apt "nano=2.9.3-2"` correctly keeps `nano` installed. Added `extractPackageNames` helper with deduplication.

## Medium
- **syncDryRunPlan error propagation** — Return and propagate `LoadState`/`ListCustomSources` errors instead of silently returning `(nil, nil)`.

## Low
- **Key→deb semantics** — Apply `key` to all subsequent `deb`/`deb-src` lines until the next `key` (fixes same-repo deb+deb-src sharing a key).
- **ReadLockFile validation** — Require non-empty package and version; reject malformed lines like `=1.0` or `pkg=`.
- **lock_test** — Fix unchecked `os.WriteFile` error.

Made with [Cursor](https://cursor.com)