### PR TITLE
fix(ux): improve doctor state message and add --no-update warning

### DIFF
--- a/internal/commands/doctor.go
+++ b/internal/commands/doctor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/apt-bundle/apt-bundle/internal/apt"
 	"github.com/apt-bundle/apt-bundle/internal/aptfile"
@@ -69,7 +70,12 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "✗ state file: %v (path: %s)\n", err, apt.StateDir)
 		failed = true
 	} else {
-		fmt.Println("✓ state file readable")
+		statePath := filepath.Join(apt.StateDir, apt.StateFile)
+		if _, err := os.Stat(statePath); err == nil {
+			fmt.Println("✓ state file readable")
+		} else {
+			fmt.Println("✓ state file OK (will be created on first install)")
+		}
 	}
 
 	if failed {

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -97,6 +97,8 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			if err := apt.Update(); err != nil {
 				return fmt.Errorf("failed to update package lists: %w", err)
 			}
+		} else if reposAdded {
+			fmt.Println("⚠️  Warning: Repositories were added; run without --no-update to fetch package lists.")
 		}
 	}
 


### PR DESCRIPTION
## Summary

Addresses 2 medium-priority UX issues from the expert code review (round 3, 14 Feb 2026).

## Changes

### 1. Doctor state file message
- **Before:** Always printed `✓ state file readable` even when the state file did not exist.
- **After:** Distinguishes between:
  - `✓ state file readable` — when the state file exists and loads successfully
  - `✓ state file OK (will be created on first install)` — when the state file does not exist (first run)

### 2. Install `--no-update` warning
- **Before:** When repositories were added with `--no-update`, package lists were not fetched and subsequent installs could fail, with no warning.
- **After:** Prints `⚠️  Warning: Repositories were added; run without --no-update to fetch package lists.` when repos are added but update is skipped.

## Testing
- Pre-commit checks passed (golangci-lint, go build)
- Existing doctor and install tests pass

Made with [Cursor](https://cursor.com)