### PR TITLE
docs: clarify error semantics, update tech spec for DEB822/keyrings

### DIFF
--- a/internal/apt/packages.go
+++ b/internal/apt/packages.go
@@ -13,7 +13,10 @@ const dpkgStatusInstalled = "install ok installed"
 // CandidateVersionNone is the apt-cache policy output when no candidate version exists
 const CandidateVersionNone = "(none)"
 
-// IsPackageInstalled checks if a package is installed on the system
+// IsPackageInstalled checks if a package is installed on the system.
+// On any dpkg-query failure (package not found, command error, permission denied),
+// it returns (false, nil). Callers cannot distinguish "not installed" from "check failed";
+// both are treated as "not installed" so install can proceed (idempotent behavior).
 func IsPackageInstalled(packageName string) (bool, error) {
 	output, err := runCommandWithOutput("dpkg-query", "-W", "-f=${Status}", packageName)
 	if err != nil {
@@ -72,7 +75,10 @@ func AutoRemove() error {
 	return nil
 }
 
-// GetInstalledVersion returns the installed version of a package, or empty string if not installed
+// GetInstalledVersion returns the installed version of a package, or empty string if not installed.
+// On any dpkg-query failure (package not found, command error, permission denied),
+// it returns ("", nil). Callers cannot distinguish "not installed" from "query failed";
+// both are treated as "no version" so callers can proceed (e.g., skip or try install).
 func GetInstalledVersion(packageName string) (string, error) {
 	output, err := runCommandWithOutput("dpkg-query", "-W", "-f=${Version}", packageName)
 	if err != nil {

--- a/specs/tech-specs.md
+++ b/specs/tech-specs.md
@@ -39,8 +39,8 @@ ppa ppa:git-core/ppa
 
 `deb` Specifies a full deb repository line to be added to /etc/apt/sources.list.d/.
 Syntax: deb "<full-repository-line>"
-Logic: The tool will create a .list file (e.g., from a hash of the line) in /etc/apt/sources.list.d/ containing the line.
-Note: This directive only adds the repository line. It does not add the GPG key. The key directive must be used separately.
+Logic: The tool creates a DEB822-format .sources file (e.g., apt-bundle-<hash>.sources) in /etc/apt/sources.list.d/.
+Note: This directive only adds the repository line. It does not add the GPG key. The key directive must be used separately. When a key directive precedes a deb directive, the key path is used for the Signed-By field in the DEB822 stanza.
 Example:
 
 ```
@@ -52,9 +52,9 @@ deb "[arch=amd64] [https://download.docker.com/linux/ubuntu](https://download.do
 ```
 
 
-`key` Specifies a GPG key URL to be downloaded and added to /etc/apt/trusted.gpg.d/.
+`key` Specifies a GPG key URL to be downloaded and added to the keyring.
 Syntax: key <url-to-key>
-Logic: The tool will download the key, dearmor it, and save it to /etc/apt/trusted.gpg.d/<filename>.gpg.
+Logic: The tool downloads the key, dearmors it if needed, and saves it to /etc/apt/keyrings/ (e.g., apt-bundle-<hash>.gpg). The key path is used for the Signed-By field when adding deb repositories, scoping trust to that repository rather than globally.
 Example:
 
 ```


### PR DESCRIPTION
- IsPackageInstalled: document that dpkg-query failures return (false, nil); callers cannot distinguish 'not installed' from 'check failed' (intentional)
- GetInstalledVersion: document that failures return ("", nil); same rationale
- Tech spec: deb creates DEB822 .sources files (not .list)
- Tech spec: key saves to /etc/apt/keyrings with Signed-By (not trusted.gpg.d)