### PR TITLE
fix: dump docs, -race in make test, SetKeyringDir for tests, CheckRedirect for HTTPS, readDEB822File comment, tech spec update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,10 @@ clean:
 	@rm -f coverage.out coverage.html
 	@echo "✓ Clean complete"
 
-# Run tests
+# Run tests (aligned with CI: -race for data race detection, -p 1 to avoid cross-package races on shared globals)
 test:
 	@echo "Running tests..."
-	$(GO) test -v ./...
+	$(GO) test -v -race -p 1 ./...
 
 # Run tests with coverage
 test-coverage:

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ apt-bundle outdated
 apt-bundle dump > Aptfile
 ```
 
+Note: `dump` emits repository lines but not key directives for repos that use Signed-By; you may need to add those manually when installing from a dumped Aptfile.
+
 ### Aptfile Format
 
 The `Aptfile` is a simple line-oriented text file with the following directives:

--- a/internal/apt/keys.go
+++ b/internal/apt/keys.go
@@ -13,11 +13,14 @@ import (
 )
 
 const (
-	// KeyringDir is where apt-bundle stores GPG keys (scoped to repos, not globally trusted)
+	// KeyringDir is the default path where apt-bundle stores GPG keys (scoped to repos, not globally trusted)
 	KeyringDir = "/etc/apt/keyrings"
 	// KeyPrefix is the prefix for apt-bundle managed key files
 	KeyPrefix = "apt-bundle-"
 )
+
+// keyringDir is the overridable keyring directory (for testing)
+var keyringDir = KeyringDir
 
 // validateKeyURL ensures the URL uses https://. Rejects http://, file://, and other schemes.
 func validateKeyURL(keyURL string) error {
@@ -43,11 +46,19 @@ func validateKeyURL(keyURL string) error {
 func KeyPathForURL(keyURL string) string {
 	hash := sha256.Sum256([]byte(keyURL))
 	filename := fmt.Sprintf("%s%x.gpg", KeyPrefix, hash[:8])
-	return filepath.Join(KeyringDir, filename)
+	return filepath.Join(keyringDir, filename)
 }
 
-// keyHTTPClient is used for key downloads; has timeout to avoid hanging
-var keyHTTPClient = &http.Client{Timeout: 30 * time.Second}
+// keyHTTPClient is used for key downloads; has timeout and enforces HTTPS on redirects
+var keyHTTPClient = &http.Client{
+	Timeout: 30 * time.Second,
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		if req.URL.Scheme != "https" {
+			return fmt.Errorf("redirect to non-HTTPS URL rejected for security: %s", req.URL)
+		}
+		return nil
+	},
+}
 
 // httpGet is the function used to make HTTP requests (overridable for testing)
 var httpGet = keyHTTPClient.Get
@@ -64,7 +75,7 @@ func AddGPGKey(keyURL string) (string, error) {
 
 	hash := sha256.Sum256([]byte(keyURL))
 	filename := fmt.Sprintf("%s%x.gpg", KeyPrefix, hash[:8])
-	keyPath := filepath.Join(KeyringDir, filename)
+	keyPath := filepath.Join(keyringDir, filename)
 
 	// Check if key already exists (idempotency)
 	if _, err := os.Stat(keyPath); err == nil {
@@ -73,7 +84,7 @@ func AddGPGKey(keyURL string) (string, error) {
 	}
 
 	// Ensure the keyring directory exists
-	if err := os.MkdirAll(KeyringDir, 0755); err != nil {
+	if err := os.MkdirAll(keyringDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create keyring directory: %w", err)
 	}
 
@@ -164,4 +175,14 @@ func SetHTTPGet(f func(string) (*http.Response, error)) {
 // ResetHTTPGet resets the HTTP get function to default (for testing only)
 func ResetHTTPGet() {
 	httpGet = keyHTTPClient.Get
+}
+
+// SetKeyringDir sets the keyring directory (for testing only)
+func SetKeyringDir(path string) {
+	keyringDir = path
+}
+
+// ResetKeyringDir resets the keyring directory to default (for testing only)
+func ResetKeyringDir() {
+	keyringDir = KeyringDir
 }

--- a/internal/apt/keys_test.go
+++ b/internal/apt/keys_test.go
@@ -16,6 +16,13 @@ func TestAddGPGKey(t *testing.T) {
 	t.Run("successful key download - binary key", func(t *testing.T) {
 		defer ResetHTTPGet()
 		defer ResetExecutor()
+		defer ResetKeyringDir()
+
+		keyringPath := filepath.Join(tmpDir, "keyrings")
+		if err := os.MkdirAll(keyringPath, 0755); err != nil {
+			t.Fatalf("Failed to create keyring dir: %v", err)
+		}
+		SetKeyringDir(keyringPath)
 
 		binaryKeyData := []byte{0x99, 0x01, 0x0d, 0x04}
 		SetHTTPGet(func(url string) (*http.Response, error) {
@@ -25,16 +32,15 @@ func TestAddGPGKey(t *testing.T) {
 			}, nil
 		})
 
-		keyringPath := filepath.Join(tmpDir, "keyrings")
-		if err := os.MkdirAll(keyringPath, 0755); err != nil {
-			t.Fatalf("Failed to create keyring dir: %v", err)
-		}
-
 		keyPath, err := AddGPGKey("https://example.com/key.gpg")
 		if err != nil {
-			t.Logf("AddGPGKey failed (expected in test environment): %v", err)
-		} else {
-			t.Logf("Key path: %s", keyPath)
+			t.Fatalf("AddGPGKey failed: %v", err)
+		}
+		if keyPath == "" {
+			t.Error("Expected non-empty key path")
+		}
+		if _, err := os.Stat(keyPath); err != nil {
+			t.Errorf("Key file should exist at %s: %v", keyPath, err)
 		}
 	})
 

--- a/internal/apt/sources.go
+++ b/internal/apt/sources.go
@@ -158,7 +158,8 @@ func readListFile(path string) ([]SourceEntry, error) {
 	return entries, sc.Err()
 }
 
-// readDEB822File parses a DEB822 .sources file and returns Aptfile entries (deb only; PPA not in .sources typically)
+// readDEB822File parses a DEB822 .sources file and returns Aptfile entries (deb only; PPA not in .sources typically).
+// Only single-stanza files are supported; files with multiple stanzas (blank-line separated) yield only the last stanza.
 func readDEB822File(path string) ([]SourceEntry, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/commands/dump.go
+++ b/internal/commands/dump.go
@@ -13,7 +13,12 @@ var dumpCmd = &cobra.Command{
 	Use:   "dump",
 	Short: "Generate an Aptfile from the current system state",
 	Long: `Dump generates an Aptfile by listing all manually installed packages
-and optionally custom PPAs and repositories from the system.`,
+and optionally custom PPAs and repositories from the system.
+
+Limitation: Repositories that use Signed-By (GPG keys) are emitted as deb lines
+only. The corresponding key directive is not included, since dump reads from
+.sources files which store key paths, not URLs. When installing from a dumped
+Aptfile, you may need to add key directives manually for custom repositories.`,
 	RunE: runDump,
 }
 

--- a/specs/tech-specs.md
+++ b/specs/tech-specs.md
@@ -1,5 +1,15 @@
 # Technical Specification: apt-bundle
 
+## Implementation Overview
+
+apt-bundle uses modern APT conventions:
+
+- **Custom repositories:** Stored as DEB822-format `.sources` files in `/etc/apt/sources.list.d/` (not legacy `.list` one-line format).
+- **GPG keys:** Stored in `/etc/apt/keyrings/` (not `/etc/apt/trusted.gpg.d/`). Keys are scoped per-repository via the `Signed-By` field in DEB822 stanzas, rather than globally trusted.
+- **Key URLs:** Only `https://` URLs are accepted; `http://` and `file://` are rejected for security.
+
+---
+
 ## Part 1: Aptfile Specification
 
 ### Overview


### PR DESCRIPTION
Minor fixes:
- Document dump round-trip limitation: Signed-By repos emit deb lines only,
  not key directives; add note to dump help and README
- Align make test with CI: add -race to test target
- Add SetKeyringDir/ResetKeyringDir for tests; keys test now uses temp dir
  instead of /etc/apt/keyrings
- Add CheckRedirect to key HTTP client to reject non-HTTPS redirects
- Add comment that readDEB822File supports single-stanza only
- Update tech spec with Implementation Overview (DEB822, keyrings, Signed-By)