### PR TITLE
refactor: idiomatic Go - DI struct, consolidate Executor, cleanup

### DIFF
--- a/internal/apt/executor.go
+++ b/internal/apt/executor.go
@@ -3,13 +3,11 @@ package apt
 import (
 	"fmt"
 	"os/exec"
-
-	"github.com/apt-bundle/apt-bundle/internal/executor"
 )
 
 type realExecutor struct{}
 
-var _ executor.Executor = (*realExecutor)(nil)
+var _ Executor = (*realExecutor)(nil)
 
 func (e *realExecutor) Run(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
@@ -23,14 +21,12 @@ func (e *realExecutor) Output(name string, args ...string) ([]byte, error) {
 	return cmd.Output()
 }
 
-var defaultExecutor executor.Executor = &realExecutor{}
-
-func runCommand(name string, args ...string) error {
-	return defaultExecutor.Run(name, args...)
+func (m *AptManager) runCommand(name string, args ...string) error {
+	return m.Executor.Run(name, args...)
 }
 
-func runCommandWithOutput(name string, args ...string) ([]byte, error) {
-	return defaultExecutor.Output(name, args...)
+func (m *AptManager) runCommandWithOutput(name string, args ...string) ([]byte, error) {
+	return m.Executor.Output(name, args...)
 }
 
 func wrapCommandError(err error, operation, target string) error {
@@ -41,14 +37,4 @@ func wrapCommandError(err error, operation, target string) error {
 		return fmt.Errorf("failed to %s: %w", operation, err)
 	}
 	return fmt.Errorf("failed to %s %s: %w", operation, target, err)
-}
-
-// SetExecutor sets the command executor (for testing only)
-func SetExecutor(e executor.Executor) {
-	defaultExecutor = e
-}
-
-// ResetExecutor resets to the default real executor (for testing only)
-func ResetExecutor() {
-	defaultExecutor = &realExecutor{}
 }

--- a/internal/apt/executor_test.go
+++ b/internal/apt/executor_test.go
@@ -7,40 +7,15 @@ import (
 	"github.com/apt-bundle/apt-bundle/internal/testutil"
 )
 
-func TestSetExecutor(t *testing.T) {
-	defer ResetExecutor()
-
-	mock := testutil.NewMockExecutor()
-	SetExecutor(mock)
-
-	_ = runCommand("test-command", "arg1", "arg2")
-
-	if len(mock.RunCalls) != 1 {
-		t.Errorf("Expected 1 run call, got %d", len(mock.RunCalls))
-	}
-
-	if mock.RunCalls[0][0] != "test-command" {
-		t.Errorf("Expected command 'test-command', got '%s'", mock.RunCalls[0][0])
-	}
-}
-
-func TestResetExecutor(t *testing.T) {
-	mock := testutil.NewMockExecutor()
-	SetExecutor(mock)
-	ResetExecutor()
-}
-
 func TestRunCommand(t *testing.T) {
-	defer ResetExecutor()
-
 	t.Run("success", func(t *testing.T) {
 		mock := testutil.NewMockExecutor()
 		mock.RunFunc = func(name string, args ...string) error {
 			return nil
 		}
-		SetExecutor(mock)
+		m := &AptManager{Executor: mock}
 
-		err := runCommand("test", "arg1")
+		err := m.runCommand("test", "arg1")
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -51,26 +26,39 @@ func TestRunCommand(t *testing.T) {
 		mock.RunFunc = func(name string, args ...string) error {
 			return errors.New("command failed")
 		}
-		SetExecutor(mock)
+		m := &AptManager{Executor: mock}
 
-		err := runCommand("test", "arg1")
+		err := m.runCommand("test", "arg1")
 		if err == nil {
 			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("records calls", func(t *testing.T) {
+		mock := testutil.NewMockExecutor()
+		m := &AptManager{Executor: mock}
+
+		_ = m.runCommand("test-command", "arg1", "arg2")
+
+		if len(mock.RunCalls) != 1 {
+			t.Errorf("Expected 1 run call, got %d", len(mock.RunCalls))
+		}
+
+		if mock.RunCalls[0][0] != "test-command" {
+			t.Errorf("Expected command 'test-command', got '%s'", mock.RunCalls[0][0])
 		}
 	})
 }
 
 func TestRunCommandWithOutput(t *testing.T) {
-	defer ResetExecutor()
-
 	t.Run("success with output", func(t *testing.T) {
 		mock := testutil.NewMockExecutor()
 		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
 			return []byte("test output"), nil
 		}
-		SetExecutor(mock)
+		m := &AptManager{Executor: mock}
 
-		output, err := runCommandWithOutput("test", "arg1")
+		output, err := m.runCommandWithOutput("test", "arg1")
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -84,9 +72,9 @@ func TestRunCommandWithOutput(t *testing.T) {
 		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
 			return nil, errors.New("command failed")
 		}
-		SetExecutor(mock)
+		m := &AptManager{Executor: mock}
 
-		_, err := runCommandWithOutput("test", "arg1")
+		_, err := m.runCommandWithOutput("test", "arg1")
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}

--- a/internal/apt/keys.go
+++ b/internal/apt/keys.go
@@ -19,9 +19,6 @@ const (
 	KeyPrefix = "apt-bundle-"
 )
 
-// keyringDir is the overridable keyring directory (for testing)
-var keyringDir = KeyringDir
-
 // validateKeyURL ensures the URL uses https://. Rejects http://, file://, and other schemes.
 func validateKeyURL(keyURL string) error {
 	u, err := url.Parse(keyURL)
@@ -43,10 +40,10 @@ func validateKeyURL(keyURL string) error {
 }
 
 // KeyPathForURL returns the path where AddGPGKey would store the key for the given URL
-func KeyPathForURL(keyURL string) string {
+func (m *AptManager) KeyPathForURL(keyURL string) string {
 	hash := sha256.Sum256([]byte(keyURL))
 	filename := fmt.Sprintf("%s%x.gpg", KeyPrefix, hash[:8])
-	return filepath.Join(keyringDir, filename)
+	return filepath.Join(m.KeyringDir, filename)
 }
 
 // keyHTTPClient is used for key downloads; has timeout and enforces HTTPS on redirects
@@ -60,13 +57,10 @@ var keyHTTPClient = &http.Client{
 	},
 }
 
-// httpGet is the function used to make HTTP requests (overridable for testing)
-var httpGet = keyHTTPClient.Get
-
 // AddGPGKey downloads and adds a GPG key from a URL
 // Returns the path to the saved key file for use with Signed-By in DEB822 format
 // Only https:// URLs are allowed; http:// and file:// are rejected for security.
-func AddGPGKey(keyURL string) (string, error) {
+func (m *AptManager) AddGPGKey(keyURL string) (string, error) {
 	if err := validateKeyURL(keyURL); err != nil {
 		return "", err
 	}
@@ -75,7 +69,7 @@ func AddGPGKey(keyURL string) (string, error) {
 
 	hash := sha256.Sum256([]byte(keyURL))
 	filename := fmt.Sprintf("%s%x.gpg", KeyPrefix, hash[:8])
-	keyPath := filepath.Join(keyringDir, filename)
+	keyPath := filepath.Join(m.KeyringDir, filename)
 
 	// Check if key already exists (idempotency)
 	if _, err := os.Stat(keyPath); err == nil {
@@ -84,12 +78,12 @@ func AddGPGKey(keyURL string) (string, error) {
 	}
 
 	// Ensure the keyring directory exists
-	if err := os.MkdirAll(keyringDir, 0755); err != nil {
+	if err := os.MkdirAll(m.KeyringDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create keyring directory: %w", err)
 	}
 
 	// Download the key
-	resp, err := httpGet(keyURL)
+	resp, err := m.HTTPGet(keyURL)
 	if err != nil {
 		return "", fmt.Errorf("failed to download key: %w", err)
 	}
@@ -106,7 +100,7 @@ func AddGPGKey(keyURL string) (string, error) {
 
 	// Check if the key is ASCII armored and needs dearmoring
 	if isArmoredKey(keyData) {
-		keyData, err = dearmorKey(keyData)
+		keyData, err = m.dearmorKey(keyData)
 		if err != nil {
 			return "", fmt.Errorf("failed to dearmor key: %w", err)
 		}
@@ -127,7 +121,7 @@ func isArmoredKey(data []byte) bool {
 }
 
 // dearmorKey converts an ASCII armored key to binary format using gpg --dearmor
-func dearmorKey(data []byte) ([]byte, error) {
+func (m *AptManager) dearmorKey(data []byte) ([]byte, error) {
 	// Create a temp file for the armored key
 	tmpFile, err := os.CreateTemp("", "apt-bundle-key-*.asc")
 	if err != nil {
@@ -151,7 +145,7 @@ func dearmorKey(data []byte) ([]byte, error) {
 	defer os.Remove(outPath)
 
 	// Run gpg --dearmor
-	if err := runCommand("gpg", "--dearmor", "-o", outPath, tmpFile.Name()); err != nil {
+	if err := m.runCommand("gpg", "--dearmor", "-o", outPath, tmpFile.Name()); err != nil {
 		return nil, fmt.Errorf("gpg --dearmor failed: %w", err)
 	}
 
@@ -165,24 +159,4 @@ func RemoveGPGKey(keyPath string) error {
 		return fmt.Errorf("failed to remove key: %w", err)
 	}
 	return nil
-}
-
-// SetHTTPGet sets the HTTP get function (for testing only)
-func SetHTTPGet(f func(string) (*http.Response, error)) {
-	httpGet = f
-}
-
-// ResetHTTPGet resets the HTTP get function to default (for testing only)
-func ResetHTTPGet() {
-	httpGet = keyHTTPClient.Get
-}
-
-// SetKeyringDir sets the keyring directory (for testing only)
-func SetKeyringDir(path string) {
-	keyringDir = path
-}
-
-// ResetKeyringDir resets the keyring directory to default (for testing only)
-func ResetKeyringDir() {
-	keyringDir = KeyringDir
 }

--- a/internal/apt/keys_test.go
+++ b/internal/apt/keys_test.go
@@ -11,28 +11,25 @@ import (
 
 func TestAddGPGKey(t *testing.T) {
 	tmpDir := t.TempDir()
-	_ = tmpDir
 
 	t.Run("successful key download - binary key", func(t *testing.T) {
-		defer ResetHTTPGet()
-		defer ResetExecutor()
-		defer ResetKeyringDir()
-
 		keyringPath := filepath.Join(tmpDir, "keyrings")
 		if err := os.MkdirAll(keyringPath, 0755); err != nil {
 			t.Fatalf("Failed to create keyring dir: %v", err)
 		}
-		SetKeyringDir(keyringPath)
 
 		binaryKeyData := []byte{0x99, 0x01, 0x0d, 0x04}
-		SetHTTPGet(func(url string) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(string(binaryKeyData))),
-			}, nil
-		})
+		m := &AptManager{
+			KeyringDir: keyringPath,
+			HTTPGet: func(url string) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(string(binaryKeyData))),
+				}, nil
+			},
+		}
 
-		keyPath, err := AddGPGKey("https://example.com/key.gpg")
+		keyPath, err := m.AddGPGKey("https://example.com/key.gpg")
 		if err != nil {
 			t.Fatalf("AddGPGKey failed: %v", err)
 		}
@@ -45,16 +42,17 @@ func TestAddGPGKey(t *testing.T) {
 	})
 
 	t.Run("HTTP error", func(t *testing.T) {
-		defer ResetHTTPGet()
+		m := &AptManager{
+			KeyringDir: tmpDir,
+			HTTPGet: func(url string) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			},
+		}
 
-		SetHTTPGet(func(url string) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: http.StatusNotFound,
-				Body:       io.NopCloser(strings.NewReader("")),
-			}, nil
-		})
-
-		_, err := AddGPGKey("https://example.com/nonexistent.gpg")
+		_, err := m.AddGPGKey("https://example.com/nonexistent.gpg")
 		if err == nil {
 			t.Error("Expected error for HTTP 404, got nil")
 		}
@@ -64,7 +62,8 @@ func TestAddGPGKey(t *testing.T) {
 	})
 
 	t.Run("reject http://", func(t *testing.T) {
-		_, err := AddGPGKey("http://example.com/key.gpg")
+		m := NewAptManager()
+		_, err := m.AddGPGKey("http://example.com/key.gpg")
 		if err == nil {
 			t.Error("Expected error for http:// URL")
 		}
@@ -74,7 +73,8 @@ func TestAddGPGKey(t *testing.T) {
 	})
 
 	t.Run("reject file://", func(t *testing.T) {
-		_, err := AddGPGKey("file:///etc/passwd")
+		m := NewAptManager()
+		_, err := m.AddGPGKey("file:///etc/passwd")
 		if err == nil {
 			t.Error("Expected error for file:// URL")
 		}
@@ -84,14 +84,16 @@ func TestAddGPGKey(t *testing.T) {
 	})
 
 	t.Run("reject invalid URL", func(t *testing.T) {
-		_, err := AddGPGKey("not-a-valid-url")
+		m := NewAptManager()
+		_, err := m.AddGPGKey("not-a-valid-url")
 		if err == nil {
 			t.Error("Expected error for invalid URL")
 		}
 	})
 
 	t.Run("reject keyserver://", func(t *testing.T) {
-		_, err := AddGPGKey("keyserver://keyserver.ubuntu.com/12345")
+		m := NewAptManager()
+		_, err := m.AddGPGKey("keyserver://keyserver.ubuntu.com/12345")
 		if err == nil {
 			t.Error("Expected error for keyserver:// URL")
 		}
@@ -143,27 +145,21 @@ func TestRemoveGPGKey(t *testing.T) {
 	})
 }
 
-func TestSetHTTPGet(t *testing.T) {
-	defer ResetHTTPGet()
-
-	customCalled := false
-	SetHTTPGet(func(url string) (*http.Response, error) {
-		customCalled = true
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader("test")),
-		}, nil
-	})
-
-	_, _ = httpGet("http://example.com")
-	if !customCalled {
-		t.Error("Custom httpGet function was not called")
+func TestKeyPathForURL(t *testing.T) {
+	m := &AptManager{KeyringDir: "/test/keyrings"}
+	path := m.KeyPathForURL("https://example.com/key.gpg")
+	if path == "" {
+		t.Error("Expected non-empty path")
+	}
+	if !strings.HasPrefix(path, "/test/keyrings/") {
+		t.Errorf("Expected path to start with /test/keyrings/, got %s", path)
 	}
 }
 
 func BenchmarkAddGPGKey(b *testing.B) {
+	m := NewAptManager()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = AddGPGKey("https://example.com/key.gpg")
+		_, _ = m.AddGPGKey("https://example.com/key.gpg")
 	}
 }

--- a/internal/apt/manager.go
+++ b/internal/apt/manager.go
@@ -1,0 +1,37 @@
+package apt
+
+import (
+	"net/http"
+	"os/exec"
+	"path/filepath"
+)
+
+// Executor runs shell commands for testing or production.
+type Executor interface {
+	Run(name string, args ...string) error
+	Output(name string, args ...string) ([]byte, error)
+}
+
+// AptManager provides dependency-injected access to apt operations.
+// Construct with NewAptManager for production defaults, or create
+// directly with custom fields for testing.
+type AptManager struct {
+	Executor      Executor
+	HTTPGet       func(string) (*http.Response, error)
+	KeyringDir    string
+	LookPath      func(string) (string, error)
+	OsReleasePath string
+	StatePath     func() string
+}
+
+// NewAptManager creates an AptManager with production defaults.
+func NewAptManager() *AptManager {
+	return &AptManager{
+		Executor:      &realExecutor{},
+		HTTPGet:       keyHTTPClient.Get,
+		KeyringDir:    KeyringDir,
+		LookPath:      exec.LookPath,
+		OsReleasePath: "/etc/os-release",
+		StatePath:     func() string { return filepath.Join(StateDir, StateFile) },
+	}
+}

--- a/internal/apt/packages.go
+++ b/internal/apt/packages.go
@@ -16,8 +16,8 @@ const CandidateVersionNone = "(none)"
 // IsPackageInstalled checks if a package is installed on the system.
 // Returns (false, err) on dpkg-query failure (package not found, command error, permission denied).
 // Callers can distinguish "not installed" (installed=false, err=nil) from "check failed" (err!=nil).
-func IsPackageInstalled(packageName string) (bool, error) {
-	output, err := runCommandWithOutput("dpkg-query", "-W", "-f=${Status}", packageName)
+func (m *AptManager) IsPackageInstalled(packageName string) (bool, error) {
+	output, err := m.runCommandWithOutput("dpkg-query", "-W", "-f=${Status}", packageName)
 	if err != nil {
 		return false, err
 	}
@@ -27,13 +27,13 @@ func IsPackageInstalled(packageName string) (bool, error) {
 }
 
 // InstallPackage installs a package using apt-get
-func InstallPackage(packageName string) error {
+func (m *AptManager) InstallPackage(packageName string) error {
 	if packageName == "" {
 		return fmt.Errorf("package name cannot be empty")
 	}
 	fmt.Printf("Installing package: %s\n", packageName)
 
-	if err := runCommand("apt-get", "install", "-y", packageName); err != nil {
+	if err := m.runCommand("apt-get", "install", "-y", packageName); err != nil {
 		return wrapCommandError(err, "install package", packageName)
 	}
 
@@ -42,10 +42,10 @@ func InstallPackage(packageName string) error {
 }
 
 // Update runs apt-get update
-func Update() error {
+func (m *AptManager) Update() error {
 	fmt.Println("Updating package lists...")
 
-	if err := runCommand("apt-get", "update"); err != nil {
+	if err := m.runCommand("apt-get", "update"); err != nil {
 		return wrapCommandError(err, "update package lists", "")
 	}
 
@@ -54,10 +54,10 @@ func Update() error {
 }
 
 // RemovePackage removes a package using apt-get
-func RemovePackage(packageName string) error {
+func (m *AptManager) RemovePackage(packageName string) error {
 	fmt.Printf("Removing package: %s\n", packageName)
 
-	if err := runCommand("apt-get", "remove", "-y", packageName); err != nil {
+	if err := m.runCommand("apt-get", "remove", "-y", packageName); err != nil {
 		return wrapCommandError(err, "remove package", packageName)
 	}
 
@@ -66,10 +66,10 @@ func RemovePackage(packageName string) error {
 }
 
 // AutoRemove removes orphaned dependencies using apt-get autoremove
-func AutoRemove() error {
+func (m *AptManager) AutoRemove() error {
 	fmt.Println("Removing orphaned dependencies...")
 
-	if err := runCommand("apt-get", "autoremove", "-y"); err != nil {
+	if err := m.runCommand("apt-get", "autoremove", "-y"); err != nil {
 		return wrapCommandError(err, "autoremove packages", "")
 	}
 
@@ -80,8 +80,8 @@ func AutoRemove() error {
 // GetInstalledVersion returns the installed version of a package, or empty string if not installed.
 // Returns ("", err) on dpkg-query failure (package not found, command error, permission denied).
 // Callers can distinguish "not installed" (version="", err=nil) from "query failed" (err!=nil).
-func GetInstalledVersion(packageName string) (string, error) {
-	output, err := runCommandWithOutput("dpkg-query", "-W", "-f=${Version}", packageName)
+func (m *AptManager) GetInstalledVersion(packageName string) (string, error) {
+	output, err := m.runCommandWithOutput("dpkg-query", "-W", "-f=${Version}", packageName)
 	if err != nil {
 		return "", err
 	}
@@ -92,8 +92,8 @@ func GetInstalledVersion(packageName string) (string, error) {
 var candidateVersionRE = regexp.MustCompile(`(?m)^\s*Candidate:\s*(.+)$`)
 
 // GetCandidateVersion returns the candidate (available) version for a package, or empty if unknown
-func GetCandidateVersion(packageName string) (string, error) {
-	output, err := runCommandWithOutput("apt-cache", "policy", packageName)
+func (m *AptManager) GetCandidateVersion(packageName string) (string, error) {
+	output, err := m.runCommandWithOutput("apt-cache", "policy", packageName)
 	if err != nil {
 		return "", err
 	}
@@ -105,15 +105,15 @@ func GetCandidateVersion(packageName string) (string, error) {
 }
 
 // CompareVersions compares two Debian package versions. Returns -1 if a < b, 0 if a == b, 1 if a > b
-func CompareVersions(a, b string) (int, error) {
+func (m *AptManager) CompareVersions(a, b string) (int, error) {
 	if a == b {
 		return 0, nil
 	}
-	_, err := runCommandWithOutput("dpkg", "--compare-versions", a, "lt", b)
+	_, err := m.runCommandWithOutput("dpkg", "--compare-versions", a, "lt", b)
 	if err == nil {
 		return -1, nil
 	}
-	_, err = runCommandWithOutput("dpkg", "--compare-versions", a, "gt", b)
+	_, err = m.runCommandWithOutput("dpkg", "--compare-versions", a, "gt", b)
 	if err == nil {
 		return 1, nil
 	}
@@ -121,8 +121,8 @@ func CompareVersions(a, b string) (int, error) {
 }
 
 // GetAllInstalledPackages returns a list of all manually installed packages
-func GetAllInstalledPackages() ([]string, error) {
-	output, err := runCommandWithOutput("apt-mark", "showmanual")
+func (m *AptManager) GetAllInstalledPackages() ([]string, error) {
+	output, err := m.runCommandWithOutput("apt-mark", "showmanual")
 	if err != nil {
 		return nil, wrapCommandError(err, "list installed packages", "")
 	}

--- a/internal/apt/packages_test.go
+++ b/internal/apt/packages_test.go
@@ -14,7 +14,8 @@ func TestIsPackageInstalled(t *testing.T) {
 			t.Skip("dpkg-query not available, skipping test")
 		}
 
-		installed, err := IsPackageInstalled("dpkg")
+		m := NewAptManager()
+		installed, err := m.IsPackageInstalled("dpkg")
 		if err != nil {
 			t.Errorf("IsPackageInstalled(dpkg) returned error: %v", err)
 		}
@@ -29,7 +30,8 @@ func TestIsPackageInstalled(t *testing.T) {
 			t.Skip("dpkg-query not available, skipping test")
 		}
 
-		installed, err := IsPackageInstalled("definitely-not-a-real-package-12345")
+		m := NewAptManager()
+		installed, err := m.IsPackageInstalled("definitely-not-a-real-package-12345")
 		// dpkg-query returns exit 1 for nonexistent packages, so err may be non-nil
 		if installed {
 			t.Errorf("IsPackageInstalled() = true for nonexistent package, want false (err: %v)", err)
@@ -41,7 +43,8 @@ func TestIsPackageInstalled(t *testing.T) {
 			t.Skip("dpkg-query not available, skipping test")
 		}
 
-		installed, err := IsPackageInstalled("")
+		m := NewAptManager()
+		installed, err := m.IsPackageInstalled("")
 		if err != nil {
 			return
 		}
@@ -54,14 +57,16 @@ func TestIsPackageInstalled(t *testing.T) {
 
 func TestInstallPackage(t *testing.T) {
 	t.Run("install without sudo", func(t *testing.T) {
-		err := InstallPackage("test-package-that-does-not-exist")
+		m := NewAptManager()
+		err := m.InstallPackage("test-package-that-does-not-exist")
 		if err == nil {
 			t.Log("Warning: InstallPackage succeeded unexpectedly (might have sudo)")
 		}
 	})
 
 	t.Run("empty package name", func(t *testing.T) {
-		err := InstallPackage("")
+		m := NewAptManager()
+		err := m.InstallPackage("")
 		if err == nil {
 			t.Error("InstallPackage('') should fail for empty package name")
 		}
@@ -70,7 +75,8 @@ func TestInstallPackage(t *testing.T) {
 
 func TestUpdate(t *testing.T) {
 	t.Run("update without sudo", func(t *testing.T) {
-		err := Update()
+		m := NewAptManager()
+		err := m.Update()
 		if err == nil {
 			t.Log("Warning: Update succeeded unexpectedly (might have sudo)")
 		}
@@ -111,23 +117,22 @@ func BenchmarkIsPackageInstalled(b *testing.B) {
 		b.Skip("dpkg-query not available, skipping benchmark")
 	}
 
+	m := NewAptManager()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = IsPackageInstalled("dpkg")
+		_, _ = m.IsPackageInstalled("dpkg")
 	}
 }
 
 func TestIsPackageInstalledWithMock(t *testing.T) {
-	defer ResetExecutor()
-
 	t.Run("package is installed", func(t *testing.T) {
 		mock := testutil.NewMockExecutor()
 		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
 			return []byte(dpkgStatusInstalled), nil
 		}
-		SetExecutor(mock)
+		m := &AptManager{Executor: mock}
 
-		installed, err := IsPackageInstalled("curl")
+		installed, err := m.IsPackageInstalled("curl")
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -148,9 +153,9 @@ func TestIsPackageInstalledWithMock(t *testing.T) {
 		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
 			return []byte("deinstall ok config-files"), nil
 		}
-		SetExecutor(mock)
+		m := &AptManager{Executor: mock}
 
-		installed, err := IsPackageInstalled("removed-package")
+		installed, err := m.IsPackageInstalled("removed-package")
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -164,9 +169,9 @@ func TestIsPackageInstalledWithMock(t *testing.T) {
 		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
 			return nil, errors.New("dpkg-query: no packages found matching nonexistent")
 		}
-		SetExecutor(mock)
+		m := &AptManager{Executor: mock}
 
-		installed, err := IsPackageInstalled("nonexistent")
+		installed, err := m.IsPackageInstalled("nonexistent")
 		if err == nil {
 			t.Error("Expected error when dpkg-query fails, got nil")
 		}
@@ -180,9 +185,9 @@ func TestIsPackageInstalledWithMock(t *testing.T) {
 		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
 			return []byte(dpkgStatusInstalled), nil
 		}
-		SetExecutor(mock)
+		m := &AptManager{Executor: mock}
 
-		_, _ = IsPackageInstalled("test-pkg")
+		_, _ = m.IsPackageInstalled("test-pkg")
 
 		expectedArgs := []string{"dpkg-query", "-W", "-f=${Status}", "test-pkg"}
 		if len(mock.OutputCalls[0]) != len(expectedArgs) {
@@ -197,16 +202,14 @@ func TestIsPackageInstalledWithMock(t *testing.T) {
 }
 
 func TestInstallPackageWithMock(t *testing.T) {
-	defer ResetExecutor()
-
 	t.Run("successful installation", func(t *testing.T) {
 		mock := testutil.NewMockExecutor()
 		mock.RunFunc = func(name string, args ...string) error {
 			return nil
 		}
-		SetExecutor(mock)
+		m := &AptManager{Executor: mock}
 
-		err := InstallPackage("curl")
+		err := m.InstallPackage("curl")
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -227,9 +230,9 @@ func TestInstallPackageWithMock(t *testing.T) {
 		mock.RunFunc = func(name string, args ...string) error {
 			return errors.New("E: Unable to locate package nonexistent")
 		}
-		SetExecutor(mock)
+		m := &AptManager{Executor: mock}
 
-		err := InstallPackage("nonexistent")
+		err := m.InstallPackage("nonexistent")
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
@@ -240,16 +243,14 @@ func TestInstallPackageWithMock(t *testing.T) {
 }
 
 func TestUpdateWithMock(t *testing.T) {
-	defer ResetExecutor()
-
 	t.Run("successful update", func(t *testing.T) {
 		mock := testutil.NewMockExecutor()
 		mock.RunFunc = func(name string, args ...string) error {
 			return nil
 		}
-		SetExecutor(mock)
+		m := &AptManager{Executor: mock}
 
-		err := Update()
+		err := m.Update()
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -270,9 +271,9 @@ func TestUpdateWithMock(t *testing.T) {
 		mock.RunFunc = func(name string, args ...string) error {
 			return errors.New("E: Could not get lock /var/lib/apt/lists/lock")
 		}
-		SetExecutor(mock)
+		m := &AptManager{Executor: mock}
 
-		err := Update()
+		err := m.Update()
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}

--- a/internal/apt/repositories.go
+++ b/internal/apt/repositories.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -17,21 +16,9 @@ const (
 	SourcesPrefix = "apt-bundle-"
 )
 
-// lookPath is the function used to look up command paths (overridable for testing)
-var lookPath = exec.LookPath
-
-// osReleasePath is the path to os-release (overridable for testing)
-var osReleasePath = "/etc/os-release"
-
-// SetOsReleasePath sets osReleasePath (for testing only)
-func SetOsReleasePath(path string) { osReleasePath = path }
-
-// ResetOsReleasePath resets osReleasePath to default (for testing only)
-func ResetOsReleasePath() { osReleasePath = "/etc/os-release" }
-
 // isUbuntu checks if the current system is Ubuntu by reading /etc/os-release
-func isUbuntu() bool {
-	data, err := os.ReadFile(osReleasePath)
+func (m *AptManager) isUbuntu() bool {
+	data, err := os.ReadFile(m.OsReleasePath)
 	if err != nil {
 		return false
 	}
@@ -41,32 +28,22 @@ func isUbuntu() bool {
 }
 
 // AddPPA adds a PPA repository using add-apt-repository
-func AddPPA(ppa string) error {
-	if !isUbuntu() {
+func (m *AptManager) AddPPA(ppa string) error {
+	if !m.isUbuntu() {
 		fmt.Println("⚠️  Warning: PPAs are designed for Ubuntu. Using on other distros may cause issues.")
 	}
 	fmt.Printf("Adding PPA: %s\n", ppa)
 
-	if _, err := lookPath("add-apt-repository"); err != nil {
+	if _, err := m.LookPath("add-apt-repository"); err != nil {
 		return fmt.Errorf("add-apt-repository not found. Please install software-properties-common")
 	}
 
-	if err := runCommand("add-apt-repository", "-y", ppa); err != nil {
+	if err := m.runCommand("add-apt-repository", "-y", ppa); err != nil {
 		return wrapCommandError(err, "add PPA", ppa)
 	}
 
 	fmt.Printf("✓ PPA %s added successfully\n", ppa)
 	return nil
-}
-
-// SetLookPath sets the lookPath function (for testing only)
-func SetLookPath(f func(string) (string, error)) {
-	lookPath = f
-}
-
-// ResetLookPath resets lookPath to the default (for testing only)
-func ResetLookPath() {
-	lookPath = exec.LookPath
 }
 
 // DebRepository represents a parsed deb repository configuration

--- a/internal/apt/repositories_test.go
+++ b/internal/apt/repositories_test.go
@@ -13,16 +13,14 @@ import (
 
 func TestIsUbuntu(t *testing.T) {
 	dir := t.TempDir()
-	defer ResetOsReleasePath()
 
 	t.Run("ID=ubuntu returns true", func(t *testing.T) {
 		f := filepath.Join(dir, "os-release-ubuntu")
 		if err := os.WriteFile(f, []byte("ID=ubuntu\nVERSION_ID=22.04\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
-		SetOsReleasePath(f)
-		defer ResetOsReleasePath()
-		if !isUbuntu() {
+		m := &AptManager{OsReleasePath: f}
+		if !m.isUbuntu() {
 			t.Error("expected isUbuntu() true for ID=ubuntu")
 		}
 	})
@@ -32,9 +30,8 @@ func TestIsUbuntu(t *testing.T) {
 		if err := os.WriteFile(f, []byte("ID=linuxmint\nID_LIKE=ubuntu\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
-		SetOsReleasePath(f)
-		defer ResetOsReleasePath()
-		if !isUbuntu() {
+		m := &AptManager{OsReleasePath: f}
+		if !m.isUbuntu() {
 			t.Error("expected isUbuntu() true for ID_LIKE=ubuntu")
 		}
 	})
@@ -44,17 +41,15 @@ func TestIsUbuntu(t *testing.T) {
 		if err := os.WriteFile(f, []byte("ID=debian\nVERSION_ID=12\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
-		SetOsReleasePath(f)
-		defer ResetOsReleasePath()
-		if isUbuntu() {
+		m := &AptManager{OsReleasePath: f}
+		if m.isUbuntu() {
 			t.Error("expected isUbuntu() false for ID=debian")
 		}
 	})
 
 	t.Run("missing file returns false", func(t *testing.T) {
-		SetOsReleasePath(filepath.Join(dir, "nonexistent"))
-		defer ResetOsReleasePath()
-		if isUbuntu() {
+		m := &AptManager{OsReleasePath: filepath.Join(dir, "nonexistent")}
+		if m.isUbuntu() {
 			t.Error("expected isUbuntu() false when os-release missing")
 		}
 	})
@@ -62,7 +57,8 @@ func TestIsUbuntu(t *testing.T) {
 
 func TestAddPPA(t *testing.T) {
 	t.Run("add-apt-repository not available", func(t *testing.T) {
-		err := AddPPA("ppa:deadsnakes/ppa")
+		m := NewAptManager()
+		err := m.AddPPA("ppa:deadsnakes/ppa")
 
 		if err != nil {
 			if _, lookupErr := exec.LookPath("add-apt-repository"); lookupErr != nil {
@@ -77,7 +73,8 @@ func TestAddPPA(t *testing.T) {
 			t.Skip("add-apt-repository not available, skipping test")
 		}
 
-		err := AddPPA("")
+		m := NewAptManager()
+		err := m.AddPPA("")
 		if err == nil {
 			t.Log("Warning: AddPPA('') succeeded unexpectedly")
 		}
@@ -88,7 +85,8 @@ func TestAddPPA(t *testing.T) {
 			t.Skip("add-apt-repository not available, skipping test")
 		}
 
-		err := AddPPA("invalid-ppa-format")
+		m := NewAptManager()
+		err := m.AddPPA("invalid-ppa-format")
 		if err == nil {
 			t.Log("Warning: AddPPA with invalid format succeeded unexpectedly")
 		}
@@ -99,7 +97,8 @@ func TestAddPPA(t *testing.T) {
 			t.Skip("add-apt-repository not available, skipping test")
 		}
 
-		err := AddPPA("ppa:deadsnakes/ppa")
+		m := NewAptManager()
+		err := m.AddPPA("ppa:deadsnakes/ppa")
 		if err == nil {
 			t.Log("Warning: AddPPA succeeded unexpectedly (might have sudo)")
 		}
@@ -298,15 +297,15 @@ func TestRemoveDebRepository(t *testing.T) {
 }
 
 func TestAddPPAWithMock(t *testing.T) {
-	defer ResetExecutor()
-	defer ResetLookPath()
-
 	t.Run("add-apt-repository not found", func(t *testing.T) {
-		SetLookPath(func(file string) (string, error) {
-			return "", errors.New("executable file not found in $PATH")
-		})
+		m := &AptManager{
+			OsReleasePath: "/nonexistent",
+			LookPath: func(file string) (string, error) {
+				return "", errors.New("executable file not found in $PATH")
+			},
+		}
 
-		err := AddPPA("ppa:test/ppa")
+		err := m.AddPPA("ppa:test/ppa")
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
@@ -316,17 +315,19 @@ func TestAddPPAWithMock(t *testing.T) {
 	})
 
 	t.Run("successful PPA addition", func(t *testing.T) {
-		SetLookPath(func(file string) (string, error) {
-			return "/usr/bin/add-apt-repository", nil
-		})
-
 		mock := testutil.NewMockExecutor()
 		mock.RunFunc = func(name string, args ...string) error {
 			return nil
 		}
-		SetExecutor(mock)
+		m := &AptManager{
+			Executor:      mock,
+			OsReleasePath: "/nonexistent",
+			LookPath: func(file string) (string, error) {
+				return "/usr/bin/add-apt-repository", nil
+			},
+		}
 
-		err := AddPPA("ppa:deadsnakes/ppa")
+		err := m.AddPPA("ppa:deadsnakes/ppa")
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -343,17 +344,19 @@ func TestAddPPAWithMock(t *testing.T) {
 	})
 
 	t.Run("PPA addition command failure", func(t *testing.T) {
-		SetLookPath(func(file string) (string, error) {
-			return "/usr/bin/add-apt-repository", nil
-		})
-
 		mock := testutil.NewMockExecutor()
 		mock.RunFunc = func(name string, args ...string) error {
 			return errors.New("E: The repository 'ppa:invalid/ppa' does not have a Release file")
 		}
-		SetExecutor(mock)
+		m := &AptManager{
+			Executor:      mock,
+			OsReleasePath: "/nonexistent",
+			LookPath: func(file string) (string, error) {
+				return "/usr/bin/add-apt-repository", nil
+			},
+		}
 
-		err := AddPPA("ppa:invalid/ppa")
+		err := m.AddPPA("ppa:invalid/ppa")
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
@@ -365,15 +368,17 @@ func TestAddPPAWithMock(t *testing.T) {
 
 	t.Run("lookPath is called with correct argument", func(t *testing.T) {
 		var calledWith string
-		SetLookPath(func(file string) (string, error) {
-			calledWith = file
-			return "/usr/bin/add-apt-repository", nil
-		})
-
 		mock := testutil.NewMockExecutor()
-		SetExecutor(mock)
+		m := &AptManager{
+			Executor:      mock,
+			OsReleasePath: "/nonexistent",
+			LookPath: func(file string) (string, error) {
+				calledWith = file
+				return "/usr/bin/add-apt-repository", nil
+			},
+		}
 
-		_ = AddPPA("ppa:test/ppa")
+		_ = m.AddPPA("ppa:test/ppa")
 
 		if calledWith != "add-apt-repository" {
 			t.Errorf("Expected lookPath to be called with 'add-apt-repository', got '%s'", calledWith)
@@ -381,15 +386,13 @@ func TestAddPPAWithMock(t *testing.T) {
 	})
 }
 
-func TestSetLookPath(t *testing.T) {
-	defer ResetLookPath()
-
+func TestLookPathField(t *testing.T) {
 	customLookPath := func(file string) (string, error) {
 		return "/custom/path", nil
 	}
-	SetLookPath(customLookPath)
+	m := &AptManager{LookPath: customLookPath}
 
-	path, err := lookPath("test")
+	path, err := m.LookPath("test")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -398,21 +401,14 @@ func TestSetLookPath(t *testing.T) {
 	}
 }
 
-func TestResetLookPath(t *testing.T) {
-	SetLookPath(func(file string) (string, error) {
-		return "/custom/path", nil
-	})
-	ResetLookPath()
-	_, _ = lookPath("ls")
-}
-
 func BenchmarkAddPPA(b *testing.B) {
 	if _, err := exec.LookPath("add-apt-repository"); err != nil {
 		b.Skip("add-apt-repository not available, skipping benchmark")
 	}
 
+	m := NewAptManager()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = AddPPA("ppa:test/ppa")
+		_ = m.AddPPA("ppa:test/ppa")
 	}
 }

--- a/internal/apt/state.go
+++ b/internal/apt/state.go
@@ -24,11 +24,6 @@ type State struct {
 	Keys         []string `json:"keys"`
 }
 
-// statePath is the function used to get the state file path (overridable for testing)
-var statePath = func() string {
-	return filepath.Join(StateDir, StateFile)
-}
-
 // NewState creates a new empty state
 func NewState() *State {
 	return &State{
@@ -40,8 +35,8 @@ func NewState() *State {
 }
 
 // LoadState loads the state from disk, or returns a new state if none exists
-func LoadState() (*State, error) {
-	path := statePath()
+func (m *AptManager) LoadState() (*State, error) {
+	path := m.StatePath()
 
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -59,9 +54,9 @@ func LoadState() (*State, error) {
 	return &state, nil
 }
 
-// Save persists the state to disk
-func (s *State) Save() error {
-	path := statePath()
+// SaveState persists the state to disk
+func (m *AptManager) SaveState(s *State) error {
+	path := m.StatePath()
 
 	// Ensure the directory exists
 	dir := filepath.Dir(path)
@@ -158,18 +153,4 @@ func (s *State) GetPackagesNotIn(packages []string) []string {
 		}
 	}
 	return result
-}
-
-// SetStatePath sets the state file path (for testing only)
-func SetStatePath(path string) {
-	statePath = func() string {
-		return path
-	}
-}
-
-// ResetStatePath resets the state path to the default (for testing only)
-func ResetStatePath() {
-	statePath = func() string {
-		return filepath.Join(StateDir, StateFile)
-	}
 }

--- a/internal/apt/state_test.go
+++ b/internal/apt/state_test.go
@@ -176,17 +176,18 @@ func TestGetPackagesNotIn(t *testing.T) {
 	})
 }
 
-func TestStatePersistence(t *testing.T) {
-	// Create a temp directory for testing
-	tmpDir, err := os.MkdirTemp("", "apt-bundle-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
+func newTestManager(t *testing.T) *AptManager {
+	t.Helper()
+	tmpDir := t.TempDir()
 	testStatePath := filepath.Join(tmpDir, "state.json")
-	SetStatePath(testStatePath)
-	defer ResetStatePath()
+	return &AptManager{
+		StatePath: func() string { return testStatePath },
+	}
+}
+
+func TestStatePersistence(t *testing.T) {
+	m := newTestManager(t)
+	testStatePath := m.StatePath()
 
 	t.Run("save and load state", func(t *testing.T) {
 		state := NewState()
@@ -195,7 +196,7 @@ func TestStatePersistence(t *testing.T) {
 		state.AddRepository("docker.sources")
 		state.AddKey("docker.gpg")
 
-		err := state.Save()
+		err := m.SaveState(state)
 		if err != nil {
 			t.Fatalf("Failed to save state: %v", err)
 		}
@@ -206,7 +207,7 @@ func TestStatePersistence(t *testing.T) {
 		}
 
 		// Load the state
-		loaded, err := LoadState()
+		loaded, err := m.LoadState()
 		if err != nil {
 			t.Fatalf("Failed to load state: %v", err)
 		}
@@ -231,18 +232,13 @@ func TestStatePersistence(t *testing.T) {
 }
 
 func TestLoadStateNonexistent(t *testing.T) {
-	// Create a temp directory for testing
-	tmpDir, err := os.MkdirTemp("", "apt-bundle-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
+	tmpDir := t.TempDir()
 	testStatePath := filepath.Join(tmpDir, "nonexistent", "state.json")
-	SetStatePath(testStatePath)
-	defer ResetStatePath()
+	m := &AptManager{
+		StatePath: func() string { return testStatePath },
+	}
 
-	state, err := LoadState()
+	state, err := m.LoadState()
 	if err != nil {
 		t.Fatalf("Expected no error for nonexistent state file, got %v", err)
 	}
@@ -256,22 +252,17 @@ func TestLoadStateNonexistent(t *testing.T) {
 }
 
 func TestSaveCreatesDirectory(t *testing.T) {
-	// Create a temp directory for testing
-	tmpDir, err := os.MkdirTemp("", "apt-bundle-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
+	tmpDir := t.TempDir()
 	// Use a nested path that doesn't exist
 	testStatePath := filepath.Join(tmpDir, "nested", "dir", "state.json")
-	SetStatePath(testStatePath)
-	defer ResetStatePath()
+	m := &AptManager{
+		StatePath: func() string { return testStatePath },
+	}
 
 	state := NewState()
 	state.AddPackage("vim")
 
-	err = state.Save()
+	err := m.SaveState(state)
 	if err != nil {
 		t.Fatalf("Failed to save state: %v", err)
 	}

--- a/internal/aptfile/parser.go
+++ b/internal/aptfile/parser.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
+// EntryType represents the kind of directive in an Aptfile (e.g. "apt", "ppa", "deb", "key").
 type EntryType string
 
 const (
@@ -16,6 +17,7 @@ const (
 	EntryTypeKey EntryType = "key"
 )
 
+// Entry represents a single parsed line from an Aptfile.
 type Entry struct {
 	Type     EntryType
 	Value    string

--- a/internal/commands/check.go
+++ b/internal/commands/check.go
@@ -53,7 +53,7 @@ func doCheck(aptFilePath string) (ok bool, missing []string, entries []aptfile.E
 		switch entry.Type {
 		case aptfile.EntryTypeApt:
 			pkgName := aptfile.ExtractPkgName(entry.Value)
-			installed, err := apt.IsPackageInstalled(pkgName)
+			installed, err := mgr.IsPackageInstalled(pkgName)
 			if err != nil {
 				return false, nil, nil, fmt.Errorf("check package %s: %w", pkgName, err)
 			}
@@ -74,7 +74,7 @@ func doCheck(aptFilePath string) (ok bool, missing []string, entries []aptfile.E
 			}
 
 		case aptfile.EntryTypeKey:
-			keyPath := apt.KeyPathForURL(entry.Value)
+			keyPath := mgr.KeyPathForURL(entry.Value)
 			if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 				missing = append(missing, "key "+entry.Value)
 			}

--- a/internal/commands/check_test.go
+++ b/internal/commands/check_test.go
@@ -51,8 +51,9 @@ func TestRunCheck(t *testing.T) {
 			}
 			return nil, errors.New("unexpected command")
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
+		origMgr := mgr
+		mgr = &apt.AptManager{Executor: mock}
+		defer func() { mgr = origMgr }()
 
 		err := runCheck(checkCmd, nil)
 		if err != nil {
@@ -75,8 +76,9 @@ func TestRunCheck(t *testing.T) {
 			}
 			return nil, errors.New("unexpected")
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
+		origMgr := mgr
+		mgr = &apt.AptManager{Executor: mock}
+		defer func() { mgr = origMgr }()
 
 		ok, missing, _, err := doCheck(tmpFile)
 		if err != nil {
@@ -104,8 +106,9 @@ func TestRunCheck(t *testing.T) {
 			}
 			return nil, errors.New("unexpected")
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
+		origMgr := mgr
+		mgr = &apt.AptManager{Executor: mock}
+		defer func() { mgr = origMgr }()
 
 		_, _, _, err := doCheck(tmpFile)
 		if err == nil {

--- a/internal/commands/cleanup.go
+++ b/internal/commands/cleanup.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/apt-bundle/apt-bundle/internal/apt"
 	"github.com/apt-bundle/apt-bundle/internal/aptfile"
 	"github.com/spf13/cobra"
 )
@@ -113,7 +112,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	}
 
 	// Load state for updating after removal
-	state, err := apt.LoadState()
+	state, err := mgr.LoadState()
 	if err != nil {
 		return fmt.Errorf("failed to load state: %w", err)
 	}
@@ -121,7 +120,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	// Remove packages
 	fmt.Printf("Removing %d packages...\n", len(packagesToRemove))
 	for _, pkg := range packagesToRemove {
-		if err := apt.RemovePackage(pkg); err != nil {
+		if err := mgr.RemovePackage(pkg); err != nil {
 			return fmt.Errorf("failed to remove package %s: %w", pkg, err)
 		}
 		// Update state
@@ -129,7 +128,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	}
 
 	// Save updated state
-	if err := state.Save(); err != nil {
+	if err := mgr.SaveState(state); err != nil {
 		return fmt.Errorf("failed to save state: %w", err)
 	}
 
@@ -137,7 +136,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 
 	// Run autoremove if requested
 	if cleanupAutoremove {
-		if err := apt.AutoRemove(); err != nil {
+		if err := mgr.AutoRemove(); err != nil {
 			return fmt.Errorf("failed to autoremove: %w", err)
 		}
 	}
@@ -164,7 +163,7 @@ func extractPackageNames(entries []aptfile.Entry) []string {
 
 // getPackagesToCleanup returns packages that were installed by apt-bundle but are no longer in Aptfile
 func getPackagesToCleanup(aptfilePackages []string) ([]string, error) {
-	state, err := apt.LoadState()
+	state, err := mgr.LoadState()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load state: %w", err)
 	}
@@ -174,7 +173,7 @@ func getPackagesToCleanup(aptfilePackages []string) ([]string, error) {
 
 // getPackagesToZap returns ALL manually installed packages that are not in Aptfile
 func getPackagesToZap(aptfilePackages []string) ([]string, error) {
-	allInstalled, err := apt.GetAllInstalledPackages()
+	allInstalled, err := mgr.GetAllInstalledPackages()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get installed packages: %w", err)
 	}

--- a/internal/commands/cleanup_test.go
+++ b/internal/commands/cleanup_test.go
@@ -39,16 +39,17 @@ func TestExtractPackageNames(t *testing.T) {
 		cleanup := setupMockRoot()
 		defer cleanup()
 
-		apt.SetExecutor(testutil.NewMockExecutor())
-		defer apt.ResetExecutor()
-
 		tmpDir := t.TempDir()
-		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
-		defer apt.ResetStatePath()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			Executor:  testutil.NewMockExecutor(),
+			StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
 
 		state := apt.NewState()
 		state.AddPackage("nano")
-		if err := state.Save(); err != nil {
+		if err := mgr.SaveState(state); err != nil {
 			t.Fatalf("Failed to save state: %v", err)
 		}
 
@@ -118,14 +119,13 @@ func TestRunCleanupWithMock(t *testing.T) {
 		defer cleanup()
 
 		mock := testutil.NewMockExecutor()
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
-
-		// Setup empty state
 		tmpDir := t.TempDir()
-		stateFile := filepath.Join(tmpDir, "state.json")
-		apt.SetStatePath(stateFile)
-		defer apt.ResetStatePath()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			Executor:  mock,
+			StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
 
 		// Create Aptfile
 		tmpFile := filepath.Join(tmpDir, "Aptfile")
@@ -162,20 +162,20 @@ func TestRunCleanupWithMock(t *testing.T) {
 		defer cleanup()
 
 		mock := testutil.NewMockExecutor()
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
+		tmpDir := t.TempDir()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			Executor:  mock,
+			StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
 
 		// Setup state with packages
-		tmpDir := t.TempDir()
-		stateFile := filepath.Join(tmpDir, "state.json")
-		apt.SetStatePath(stateFile)
-		defer apt.ResetStatePath()
-
 		state := apt.NewState()
 		state.AddPackage("vim")
 		state.AddPackage("curl")
 		state.AddPackage("git") // This one should be removed
-		if err := state.Save(); err != nil {
+		if err := mgr.SaveState(state); err != nil {
 			t.Fatalf("Failed to save state: %v", err)
 		}
 
@@ -224,20 +224,20 @@ func TestRunCleanupWithMock(t *testing.T) {
 		mock.RunFunc = func(name string, args ...string) error {
 			return nil
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
+		tmpDir := t.TempDir()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			Executor:  mock,
+			StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
 
 		// Setup state with packages
-		tmpDir := t.TempDir()
-		stateFile := filepath.Join(tmpDir, "state.json")
-		apt.SetStatePath(stateFile)
-		defer apt.ResetStatePath()
-
 		state := apt.NewState()
 		state.AddPackage("vim")
 		state.AddPackage("curl")
 		state.AddPackage("git") // This one should be removed
-		if err := state.Save(); err != nil {
+		if err := mgr.SaveState(state); err != nil {
 			t.Fatalf("Failed to save state: %v", err)
 		}
 
@@ -283,7 +283,7 @@ func TestRunCleanupWithMock(t *testing.T) {
 		}
 
 		// Verify state was updated
-		updatedState, err := apt.LoadState()
+		updatedState, err := mgr.LoadState()
 		if err != nil {
 			t.Fatalf("Failed to load state: %v", err)
 		}
@@ -300,19 +300,19 @@ func TestRunCleanupWithMock(t *testing.T) {
 		mock.RunFunc = func(name string, args ...string) error {
 			return nil
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
+		tmpDir := t.TempDir()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			Executor:  mock,
+			StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
 
 		// Setup state with packages
-		tmpDir := t.TempDir()
-		stateFile := filepath.Join(tmpDir, "state.json")
-		apt.SetStatePath(stateFile)
-		defer apt.ResetStatePath()
-
 		state := apt.NewState()
 		state.AddPackage("vim")
 		state.AddPackage("git") // This one should be removed
-		if err := state.Save(); err != nil {
+		if err := mgr.SaveState(state); err != nil {
 			t.Fatalf("Failed to save state: %v", err)
 		}
 
@@ -365,8 +365,11 @@ func TestRunCleanupWithMock(t *testing.T) {
 		}
 
 		tmpDir := t.TempDir()
-		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
-		defer apt.ResetStatePath()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
 
 		tmpFile := filepath.Join(tmpDir, "Aptfile")
 		content := "apt vim\n"
@@ -399,8 +402,11 @@ func TestRunCleanupWithMock(t *testing.T) {
 		defer cleanup()
 
 		tmpDir := t.TempDir()
-		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
-		defer apt.ResetStatePath()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
 
 		tmpFile := filepath.Join(tmpDir, "Aptfile")
 		content := "invalid-directive value\n"
@@ -425,9 +431,11 @@ func TestRunCleanupWithMock(t *testing.T) {
 
 func TestGetPackagesToCleanup(t *testing.T) {
 	tmpDir := t.TempDir()
-	stateFile := filepath.Join(tmpDir, "state.json")
-	apt.SetStatePath(stateFile)
-	defer apt.ResetStatePath()
+	origMgr := mgr
+	mgr = &apt.AptManager{
+		StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+	}
+	defer func() { mgr = origMgr }()
 
 	// Setup state
 	state := apt.NewState()
@@ -435,7 +443,7 @@ func TestGetPackagesToCleanup(t *testing.T) {
 	state.AddPackage("curl")
 	state.AddPackage("git")
 	state.AddPackage("htop")
-	if err := state.Save(); err != nil {
+	if err := mgr.SaveState(state); err != nil {
 		t.Fatalf("Failed to save state: %v", err)
 	}
 
@@ -478,8 +486,9 @@ func TestGetPackagesToZap(t *testing.T) {
 		}
 		return nil, nil
 	}
-	apt.SetExecutor(mock)
-	defer apt.ResetExecutor()
+	origMgr := mgr
+	mgr = &apt.AptManager{Executor: mock}
+	defer func() { mgr = origMgr }()
 
 	t.Run("some packages to zap", func(t *testing.T) {
 		toZap, err := getPackagesToZap([]string{"vim", "curl"})

--- a/internal/commands/doctor.go
+++ b/internal/commands/doctor.go
@@ -66,7 +66,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		fmt.Println("✓ add-apt-repository available")
 	}
 
-	if _, err := apt.LoadState(); err != nil {
+	if _, err := mgr.LoadState(); err != nil {
 		fmt.Fprintf(os.Stderr, "✗ state file: %v (path: %s)\n", err, apt.StateDir)
 		failed = true
 	} else {

--- a/internal/commands/dump.go
+++ b/internal/commands/dump.go
@@ -32,7 +32,7 @@ func runDump(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 
 	fmt.Println("# --- Packages ---")
-	packages, err := apt.GetAllInstalledPackages()
+	packages, err := mgr.GetAllInstalledPackages()
 	if err != nil {
 		return fmt.Errorf("failed to list installed packages: %w", err)
 	}

--- a/internal/commands/dump_test.go
+++ b/internal/commands/dump_test.go
@@ -20,8 +20,9 @@ func TestRunDump(t *testing.T) {
 			}
 			return nil, errors.New("unexpected command")
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
+		origMgr := mgr
+		mgr = &apt.AptManager{Executor: mock}
+		defer func() { mgr = origMgr }()
 
 		old := os.Stdout
 		r, w, _ := os.Pipe()
@@ -71,8 +72,9 @@ func TestRunDump(t *testing.T) {
 			}
 			return nil, nil
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
+		origMgr := mgr
+		mgr = &apt.AptManager{Executor: mock}
+		defer func() { mgr = origMgr }()
 
 		err := runDump(dumpCmd, []string{})
 		if err == nil {

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -12,7 +12,6 @@ import (
 )
 
 var (
-	noUpdate      bool
 	installLock   bool
 	installLocked bool
 	installDryRun bool
@@ -29,7 +28,6 @@ var installCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.PersistentFlags().BoolVar(&noUpdate, "no-update", false, "Skip updating package lists before installing")
 	installCmd.Flags().BoolVar(&installLock, "lock", false, "After install, write Aptfile.lock with current package versions")
 	installCmd.Flags().BoolVar(&installLocked, "locked", false, "Install only versions from Aptfile.lock (fail if lock missing)")
 	installCmd.Flags().BoolVar(&installDryRun, "dry-run", false, "Only report what would be installed/added; do not run apt or change state")
@@ -57,7 +55,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		return runInstallDryRun(entries)
 	}
 
-	state, err := apt.LoadState()
+	state, err := mgr.LoadState()
 	if err != nil {
 		return fmt.Errorf("failed to load state: %w", err)
 	}
@@ -68,7 +66,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	for _, entry := range entries {
 		switch entry.Type {
 		case aptfile.EntryTypeKey:
-			keyPath, err := apt.AddGPGKey(entry.Value)
+			keyPath, err := mgr.AddGPGKey(entry.Value)
 			if err != nil {
 				return fmt.Errorf("failed to add GPG key: %w", err)
 			}
@@ -76,7 +74,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			state.AddKey(keyPath)
 
 		case aptfile.EntryTypePPA:
-			if err := apt.AddPPA(entry.Value); err != nil {
+			if err := mgr.AddPPA(entry.Value); err != nil {
 				return fmt.Errorf("failed to add PPA: %w", err)
 			}
 			reposAdded = true
@@ -94,7 +92,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 
 	if reposAdded || !noUpdate {
 		if !noUpdate {
-			if err := apt.Update(); err != nil {
+			if err := mgr.Update(); err != nil {
 				return fmt.Errorf("failed to update package lists: %w", err)
 			}
 		} else if reposAdded {
@@ -121,7 +119,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Installing %d packages...\n", len(packagesToInstall))
 		for _, pkg := range packagesToInstall {
 			pkgName := aptfile.ExtractPkgName(pkg)
-			installed, err := apt.IsPackageInstalled(pkgName)
+			installed, err := mgr.IsPackageInstalled(pkgName)
 			if err != nil {
 				fmt.Printf("Warning: Could not check if %s is installed: %v\n", pkgName, err)
 			}
@@ -133,7 +131,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 				continue
 			}
 
-			if err := apt.InstallPackage(pkg); err != nil {
+			if err := mgr.InstallPackage(pkg); err != nil {
 				return fmt.Errorf("failed to install package %s: %w", pkg, err)
 			}
 
@@ -146,7 +144,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	}
 
 	// Save the updated state
-	if err := state.Save(); err != nil {
+	if err := mgr.SaveState(state); err != nil {
 		return fmt.Errorf("failed to save state: %w", err)
 	}
 
@@ -167,7 +165,7 @@ func writeLockFileFromPackages(packages []string) error {
 	var locked []pkgVer
 	for _, pkg := range packages {
 		pkgName := aptfile.ExtractPkgName(pkg)
-		ver, err := apt.GetInstalledVersion(pkgName)
+		ver, err := mgr.GetInstalledVersion(pkgName)
 		if err != nil || ver == "" {
 			continue
 		}
@@ -199,7 +197,7 @@ func runInstallDryRun(entries []aptfile.Entry) error {
 	for _, entry := range entries {
 		switch entry.Type {
 		case aptfile.EntryTypeKey:
-			keyPath := apt.KeyPathForURL(entry.Value)
+			keyPath := mgr.KeyPathForURL(entry.Value)
 			if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 				wouldAddKeys = append(wouldAddKeys, entry.Value)
 			}
@@ -215,7 +213,7 @@ func runInstallDryRun(entries []aptfile.Entry) error {
 			}
 		case aptfile.EntryTypeApt:
 			pkgName := aptfile.ExtractPkgName(entry.Value)
-			installed, err := apt.IsPackageInstalled(pkgName)
+			installed, err := mgr.IsPackageInstalled(pkgName)
 			if err != nil || !installed {
 				wouldInstall = append(wouldInstall, entry.Value)
 			}

--- a/internal/commands/install_test.go
+++ b/internal/commands/install_test.go
@@ -106,12 +106,14 @@ func TestRunInstall(t *testing.T) {
 		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
 			return nil, errors.New("package not found")
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
 
 		tmpDir := t.TempDir()
-		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
-		defer apt.ResetStatePath()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			Executor:  mock,
+			StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
 
 		tmpFile := filepath.Join(tmpDir, "Aptfile")
 		content := "apt curl\napt git\n"
@@ -155,8 +157,9 @@ func TestRunInstallDryRun(t *testing.T) {
 		}
 		return nil, errors.New("unexpected")
 	}
-	apt.SetExecutor(mock)
-	defer apt.ResetExecutor()
+	origMgr := mgr
+	mgr = &apt.AptManager{Executor: mock}
+	defer func() { mgr = origMgr }()
 
 	installDryRun = true
 	defer func() { installDryRun = false }()
@@ -176,7 +179,6 @@ func TestRunInstallWithMock(t *testing.T) {
 	t.Run("nonexistent aptfile", func(t *testing.T) {
 		cleanup := setupMockRoot()
 		defer cleanup()
-		defer apt.ResetExecutor()
 
 		originalPath := aptfilePath
 		defer func() { aptfilePath = originalPath }()
@@ -191,7 +193,6 @@ func TestRunInstallWithMock(t *testing.T) {
 	t.Run("invalid aptfile", func(t *testing.T) {
 		cleanup := setupMockRoot()
 		defer cleanup()
-		defer apt.ResetExecutor()
 
 		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "Aptfile")
@@ -216,12 +217,13 @@ func TestRunInstallWithMock(t *testing.T) {
 		defer cleanup()
 
 		mock := testutil.NewMockExecutor()
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
-
 		tmpDir := t.TempDir()
-		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
-		defer apt.ResetStatePath()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			Executor:  mock,
+			StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
 
 		originalNoUpdate := noUpdate
 		defer func() { noUpdate = originalNoUpdate }()
@@ -255,12 +257,14 @@ func TestRunInstallWithMock(t *testing.T) {
 		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
 			return nil, errors.New("package not found")
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
 
 		tmpDir := t.TempDir()
-		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
-		defer apt.ResetStatePath()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			Executor:  mock,
+			StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
 
 		originalNoUpdate := noUpdate
 		defer func() { noUpdate = originalNoUpdate }()
@@ -305,12 +309,14 @@ func TestRunInstallWithMock(t *testing.T) {
 		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
 			return nil, errors.New("package not found")
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
 
 		tmpDir := t.TempDir()
-		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
-		defer apt.ResetStatePath()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			Executor:  mock,
+			StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
 
 		originalNoUpdate := noUpdate
 		defer func() { noUpdate = originalNoUpdate }()
@@ -350,13 +356,14 @@ func TestRunInstallWithMock(t *testing.T) {
 		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
 			return []byte("install ok installed"), nil
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
 
-		// Setup state path
 		tmpDir := t.TempDir()
-		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
-		defer apt.ResetStatePath()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			Executor:  mock,
+			StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
 
 		originalNoUpdate := noUpdate
 		defer func() { noUpdate = originalNoUpdate }()
@@ -396,13 +403,14 @@ func TestRunInstallWithMock(t *testing.T) {
 			}
 			return nil
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
 
-		// Setup state path
 		tmpDir := t.TempDir()
-		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
-		defer apt.ResetStatePath()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			Executor:  mock,
+			StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
 
 		originalNoUpdate := noUpdate
 		defer func() { noUpdate = originalNoUpdate }()
@@ -439,13 +447,14 @@ func TestRunInstallWithMock(t *testing.T) {
 		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
 			return nil, errors.New("package not found")
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
 
-		// Setup state path
 		tmpDir := t.TempDir()
-		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
-		defer apt.ResetStatePath()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			Executor:  mock,
+			StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
 
 		originalNoUpdate := noUpdate
 		defer func() { noUpdate = originalNoUpdate }()
@@ -481,13 +490,14 @@ func TestRunInstallWithMock(t *testing.T) {
 			checkCalls++
 			return nil, errors.New("dpkg-query failed")
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
 
-		// Setup state path
 		tmpDir := t.TempDir()
-		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
-		defer apt.ResetStatePath()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			Executor:  mock,
+			StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
 
 		originalNoUpdate := noUpdate
 		defer func() { noUpdate = originalNoUpdate }()

--- a/internal/commands/lock.go
+++ b/internal/commands/lock.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/apt-bundle/apt-bundle/internal/apt"
 	"github.com/apt-bundle/apt-bundle/internal/aptfile"
 	"github.com/spf13/cobra"
 )
@@ -53,7 +52,7 @@ func runLock(cmd *cobra.Command, args []string) error {
 	var locked []pkgVer
 	for _, pkg := range packages {
 		pkgName := aptfile.ExtractPkgName(pkg)
-		ver, err := apt.GetInstalledVersion(pkgName)
+		ver, err := mgr.GetInstalledVersion(pkgName)
 		if err != nil || ver == "" {
 			fmt.Printf("Warning: %s not installed, skipping in lock file\n", pkgName)
 			continue

--- a/internal/commands/outdated.go
+++ b/internal/commands/outdated.go
@@ -52,21 +52,21 @@ func collectOutdated(aptFilePath string) (outdated []OutdatedEntry, numApt int, 
 	}
 
 	for _, pkg := range packages {
-		installed, err := apt.GetInstalledVersion(pkg)
+		installed, err := mgr.GetInstalledVersion(pkg)
 		if err != nil {
 			return nil, numApt, fmt.Errorf("failed to get installed version of %s: %w", pkg, err)
 		}
 		if installed == "" {
 			continue
 		}
-		candidate, err := apt.GetCandidateVersion(pkg)
+		candidate, err := mgr.GetCandidateVersion(pkg)
 		if err != nil {
 			return nil, numApt, fmt.Errorf("failed to get candidate version of %s: %w", pkg, err)
 		}
 		if candidate == "" || candidate == apt.CandidateVersionNone {
 			continue
 		}
-		cmp, err := apt.CompareVersions(installed, candidate)
+		cmp, err := mgr.CompareVersions(installed, candidate)
 		if err != nil {
 			return nil, numApt, fmt.Errorf("version comparison for %s: %w", pkg, err)
 		}

--- a/internal/commands/outdated_test.go
+++ b/internal/commands/outdated_test.go
@@ -54,8 +54,9 @@ func TestRunOutdated(t *testing.T) {
 			}
 			return nil, errors.New("unexpected command: " + name)
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
+		origMgr := mgr
+		mgr = &apt.AptManager{Executor: mock}
+		defer func() { mgr = origMgr }()
 
 		r, w, err := os.Pipe()
 		if err != nil {
@@ -108,8 +109,9 @@ func TestRunOutdated(t *testing.T) {
 			}
 			return nil, errors.New("unexpected: " + name)
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
+		origMgr := mgr
+		mgr = &apt.AptManager{Executor: mock}
+		defer func() { mgr = origMgr }()
 
 		outdated, numApt, err := collectOutdated(aptPath)
 		if err != nil {

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -4,13 +4,18 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/apt-bundle/apt-bundle/internal/apt"
 	"github.com/spf13/cobra"
 )
 
 var (
 	aptfilePath string
+	noUpdate    bool
 	version     = "dev"
 )
+
+// mgr is the AptManager used by all commands.
+var mgr = apt.NewAptManager()
 
 var rootCmd = &cobra.Command{
 	Use:   "apt-bundle",
@@ -27,6 +32,7 @@ func Execute() error {
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&aptfilePath, "file", "f", "Aptfile", "Path to Aptfile")
+	rootCmd.PersistentFlags().BoolVar(&noUpdate, "no-update", false, "Skip updating package lists before installing")
 }
 
 // getEuid is the function used to get effective UID (overridable for testing)

--- a/internal/commands/sync.go
+++ b/internal/commands/sync.go
@@ -89,7 +89,7 @@ func runSyncDryRun() error {
 
 // syncDryRunPlan returns packages that would be installed and that would be removed
 func syncDryRunPlan(entries []aptfile.Entry) (wouldInstall, wouldRemove []string, err error) {
-	state, err := apt.LoadState()
+	state, err := mgr.LoadState()
 	if err != nil {
 		return nil, nil, fmt.Errorf("load state: %w", err)
 	}
@@ -108,7 +108,7 @@ func syncDryRunPlan(entries []aptfile.Entry) (wouldInstall, wouldRemove []string
 			continue
 		}
 		pkgName := aptfile.ExtractPkgName(entry.Value)
-		installed, err := apt.IsPackageInstalled(pkgName)
+		installed, err := mgr.IsPackageInstalled(pkgName)
 		if err != nil || !installed {
 			wouldInstall = append(wouldInstall, entry.Value)
 		}

--- a/internal/commands/sync_test.go
+++ b/internal/commands/sync_test.go
@@ -48,9 +48,6 @@ func TestRunSyncDryRun(t *testing.T) {
 	aptfilePath = tmpFile
 	defer func() { aptfilePath = origPath }()
 
-	apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
-	defer apt.ResetStatePath()
-
 	mock := testutil.NewMockExecutor()
 	mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
 		if name == "dpkg-query" {
@@ -58,8 +55,12 @@ func TestRunSyncDryRun(t *testing.T) {
 		}
 		return nil, errors.New("unexpected")
 	}
-	apt.SetExecutor(mock)
-	defer apt.ResetExecutor()
+	origMgr := mgr
+	mgr = &apt.AptManager{
+		Executor:  mock,
+		StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+	}
+	defer func() { mgr = origMgr }()
 
 	syncDryRun = true
 	defer func() { syncDryRun = false }()
@@ -85,12 +86,14 @@ func TestRunSyncWithMock(t *testing.T) {
 		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
 			return nil, errors.New("package not found")
 		}
-		apt.SetExecutor(mock)
-		defer apt.ResetExecutor()
 
 		tmpDir := t.TempDir()
-		apt.SetStatePath(filepath.Join(tmpDir, "state.json"))
-		defer apt.ResetStatePath()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			Executor:  mock,
+			StatePath: func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
 
 		tmpFile := filepath.Join(tmpDir, "Aptfile")
 		content := "apt curl\napt git\n"

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -1,7 +1,0 @@
-package executor
-
-// Executor runs shell commands for testing or production.
-type Executor interface {
-	Run(name string, args ...string) error
-	Output(name string, args ...string) ([]byte, error)
-}

--- a/internal/testutil/mock.go
+++ b/internal/testutil/mock.go
@@ -1,10 +1,6 @@
 package testutil
 
-import "github.com/apt-bundle/apt-bundle/internal/executor"
-
-// MockExecutor implements executor.Executor for testing.
-var _ executor.Executor = (*MockExecutor)(nil)
-
+// MockExecutor implements the Executor interface (defined in internal/apt) for testing.
 type MockExecutor struct {
 	RunFunc     func(name string, args ...string) error
 	OutputFunc  func(name string, args ...string) ([]byte, error)

--- a/tools.go
+++ b/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 // Package tools tracks tool dependencies for this project
 package tools


### PR DESCRIPTION
## Summary
- Replace all package-level `Set*/Reset*` test helpers in `internal/apt` with dependency injection via an `AptManager` struct holding injectable dependencies (Executor, HTTPGet, KeyringDir, LookPath, OsReleasePath, StatePath)
- Delete `internal/executor` package and move the `Executor` interface into `internal/apt` where it is consumed (idiomatic Go interface placement)
- Move `--no-update` persistent flag registration from `install.go init()` to `root.go init()`, add godoc comments to exported types in `parser.go`, remove redundant old-style `// +build tools` tag

## Testing Done
- [x] Unit tests updated across all packages to use struct-based DI instead of Set/Reset helpers
- [x] `make test` passes with `-race` flag — all packages green
- [x] Verified no remaining `apt.Set*/apt.Reset*` or `state.Save()` references
- [x] Verified `internal/executor/` directory deleted
- [x] Net result: 29 files changed, 424 insertions, 476 deletions (fewer lines overall)