### PR TITLE
fix: address correctness and logic bugs from code review

### DIFF
--- a/internal/apt/repositories.go
+++ b/internal/apt/repositories.go
@@ -17,15 +17,33 @@ const (
 	SourcesPrefix = "apt-bundle-"
 )
 
-// isUbuntu checks if the current system is Ubuntu by reading /etc/os-release
+// isUbuntu checks if the current system is Ubuntu by reading /etc/os-release.
+// Parses key=value pairs properly to avoid false positives from fields like
+// PRETTY_NAME or derivative distro IDs.
 func (m *AptManager) isUbuntu() bool {
 	data, err := os.ReadFile(m.OsReleasePath)
 	if err != nil {
 		return false
 	}
-	content := string(data)
-	return strings.Contains(content, "ID=ubuntu") ||
-		strings.Contains(content, "ID_LIKE=ubuntu")
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		key, val, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		val = strings.Trim(val, "\"")
+		if key == "ID" && val == "ubuntu" {
+			return true
+		}
+		if key == "ID_LIKE" {
+			for _, word := range strings.Fields(val) {
+				if word == "ubuntu" {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // AddPPA adds a PPA repository using add-apt-repository

--- a/internal/apt/repositories_test.go
+++ b/internal/apt/repositories_test.go
@@ -47,6 +47,39 @@ func TestIsUbuntu(t *testing.T) {
 		}
 	})
 
+	t.Run("ID_LIKE with multiple values returns true", func(t *testing.T) {
+		f := filepath.Join(dir, "os-release-pop")
+		if err := os.WriteFile(f, []byte("ID=pop\nID_LIKE=\"ubuntu debian\"\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		m := &AptManager{OsReleasePath: f}
+		if !m.isUbuntu() {
+			t.Error("expected isUbuntu() true for ID_LIKE containing ubuntu")
+		}
+	})
+
+	t.Run("PRETTY_NAME containing ubuntu does not false-match", func(t *testing.T) {
+		f := filepath.Join(dir, "os-release-pretty")
+		if err := os.WriteFile(f, []byte("PRETTY_NAME=\"Something ubuntu-based\"\nID=custom\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		m := &AptManager{OsReleasePath: f}
+		if m.isUbuntu() {
+			t.Error("expected isUbuntu() false when only PRETTY_NAME contains ubuntu")
+		}
+	})
+
+	t.Run("ID=ubuntu-derived does not match", func(t *testing.T) {
+		f := filepath.Join(dir, "os-release-derived")
+		if err := os.WriteFile(f, []byte("ID=ubuntu-derived\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		m := &AptManager{OsReleasePath: f}
+		if m.isUbuntu() {
+			t.Error("expected isUbuntu() false for ID=ubuntu-derived")
+		}
+	})
+
 	t.Run("missing file returns false", func(t *testing.T) {
 		m := &AptManager{OsReleasePath: filepath.Join(dir, "nonexistent")}
 		if m.isUbuntu() {

--- a/internal/apt/sources.go
+++ b/internal/apt/sources.go
@@ -89,7 +89,7 @@ func ListCustomSources(sourcesListPath, sourcesDir string) ([]SourceEntry, error
 		return nil, fmt.Errorf("reading %s: %w", sourcesListPath, err)
 	}
 	if err == nil {
-		lines := strings.Split(string(data), "\n")
+		lines, _ := splitLines(string(data))
 		for _, line := range lines {
 			if e, ok := parseDebLineToSource(line); ok && !seen[e.AptfileLine] {
 				seen[e.AptfileLine] = true
@@ -164,15 +164,43 @@ func readListFile(path string) ([]SourceEntry, error) {
 }
 
 // readDEB822File parses a DEB822 .sources file and returns Aptfile entries (deb only; PPA not in .sources typically).
-// Only single-stanza files are supported; files with multiple stanzas (blank-line separated) yield only the last stanza.
+// Supports multi-stanza files where stanzas are separated by blank lines.
 func readDEB822File(path string) ([]SourceEntry, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	// Simple key-value parse: Types, URIs, Suites, Components, Architectures
+
+	lines, _ := splitLines(string(data))
+	var entries []SourceEntry
+	var stanzaLines []string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			if len(stanzaLines) > 0 {
+				if entry, ok := parseDEB822Stanza(stanzaLines); ok {
+					entries = append(entries, entry)
+				}
+				stanzaLines = nil
+			}
+			continue
+		}
+		stanzaLines = append(stanzaLines, line)
+	}
+	// Handle final stanza (no trailing blank line)
+	if len(stanzaLines) > 0 {
+		if entry, ok := parseDEB822Stanza(stanzaLines); ok {
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries, nil
+}
+
+// parseDEB822Stanza parses a single DEB822 stanza (key-value pairs) into a SourceEntry.
+func parseDEB822Stanza(lines []string) (SourceEntry, bool) {
 	var types, uris, suites, components, architectures string
-	lines := strings.Split(string(data), "\n")
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
@@ -196,10 +224,10 @@ func readDEB822File(path string) ([]SourceEntry, error) {
 		}
 	}
 	if uris == "" || suites == "" {
-		return nil, nil
+		return SourceEntry{}, false
 	}
 	if isDefaultURI(uris) {
-		return nil, nil
+		return SourceEntry{}, false
 	}
 	// Build deb line: [arch=X] URI Suite Components
 	debType := "deb"
@@ -214,5 +242,5 @@ func readDEB822File(path string) ([]SourceEntry, error) {
 	if components != "" {
 		line += " " + components
 	}
-	return []SourceEntry{{Type: "deb", AptfileLine: line}}, nil
+	return SourceEntry{Type: "deb", AptfileLine: line}, true
 }

--- a/internal/apt/sources_test.go
+++ b/internal/apt/sources_test.go
@@ -252,3 +252,35 @@ Suites: jammy
 		})
 	}
 }
+
+func TestReadDEB822FileMultiStanza(t *testing.T) {
+	content := `Types: deb
+URIs: https://repo-a.example.com/apt
+Suites: focal
+Components: main
+
+Types: deb
+URIs: https://repo-b.example.com/apt
+Suites: jammy
+Components: stable
+Architectures: amd64
+`
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "multi.sources")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := readDEB822File(path)
+	if err != nil {
+		t.Fatalf("readDEB822File: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries for multi-stanza file, got %d", len(entries))
+	}
+	if entries[0].AptfileLine != "deb https://repo-a.example.com/apt focal main" {
+		t.Errorf("stanza 1: got %q", entries[0].AptfileLine)
+	}
+	if entries[1].AptfileLine != "deb [arch=amd64] https://repo-b.example.com/apt jammy stable" {
+		t.Errorf("stanza 2: got %q", entries[1].AptfileLine)
+	}
+}

--- a/internal/commands/check.go
+++ b/internal/commands/check.go
@@ -54,10 +54,7 @@ func doCheck(aptFilePath string) (ok bool, missing []string, entries []aptfile.E
 		case aptfile.EntryTypeApt:
 			pkgName := aptfile.ExtractPkgName(entry.Value)
 			installed, err := mgr.IsPackageInstalled(pkgName)
-			if err != nil {
-				return false, nil, nil, fmt.Errorf("check package %s: %w", pkgName, err)
-			}
-			if !installed {
+			if err != nil || !installed {
 				missing = append(missing, pkgName)
 			}
 

--- a/internal/commands/check_test.go
+++ b/internal/commands/check_test.go
@@ -92,7 +92,7 @@ func TestRunCheck(t *testing.T) {
 		}
 	})
 
-	t.Run("doCheck returns error when package check fails", func(t *testing.T) {
+	t.Run("doCheck treats dpkg-query error as not-installed", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "Aptfile")
 		if err := os.WriteFile(tmpFile, []byte("apt somepkg\n"), 0644); err != nil {
@@ -110,9 +110,15 @@ func TestRunCheck(t *testing.T) {
 		mgr = &apt.AptManager{Executor: mock}
 		defer func() { mgr = origMgr }()
 
-		_, _, _, err := doCheck(tmpFile)
-		if err == nil {
-			t.Error("expected doCheck to return error when dpkg-query fails")
+		ok, missing, _, err := doCheck(tmpFile)
+		if err != nil {
+			t.Fatalf("doCheck should not return error for dpkg-query failure: %v", err)
+		}
+		if ok {
+			t.Error("expected ok=false")
+		}
+		if len(missing) != 1 || missing[0] != "somepkg" {
+			t.Errorf("expected missing=[somepkg], got %v", missing)
 		}
 	})
 

--- a/internal/commands/cleanup.go
+++ b/internal/commands/cleanup.go
@@ -38,8 +38,13 @@ func init() {
 }
 
 func runCleanup(cmd *cobra.Command, args []string) error {
+	return doCleanup(cleanupForce, cleanupZap, cleanupAutoremove)
+}
+
+// doCleanup performs cleanup with explicit parameters, avoiding mutation of package-level flags.
+func doCleanup(force, zap, autoremove bool) error {
 	// Check for root privileges if actually removing packages
-	if cleanupForce {
+	if force {
 		if err := checkRoot(); err != nil {
 			return err
 		}
@@ -58,7 +63,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 
 	var packagesToRemove []string
 
-	if cleanupZap {
+	if zap {
 		// Zap mode: remove ALL packages not in Aptfile
 		packagesToRemove, err = getPackagesToZap(aptfilePackages)
 		if err != nil {
@@ -78,7 +83,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	}
 
 	// Display what will be removed
-	if cleanupZap {
+	if zap {
 		fmt.Printf("\n⚠️  ZAP MODE: The following %d packages are NOT in your Aptfile and will be removed:\n", len(packagesToRemove))
 	} else {
 		fmt.Printf("\nThe following %d packages were installed by apt-bundle but are no longer in your Aptfile:\n", len(packagesToRemove))
@@ -89,13 +94,13 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Println()
 
-	if !cleanupForce {
+	if !force {
 		fmt.Println("Run with --force to actually remove these packages")
 		return nil
 	}
 
 	// If zap mode, require explicit confirmation
-	if cleanupZap {
+	if zap {
 		fmt.Print("⚠️  WARNING: This will remove packages that may be critical to your system.\n")
 		fmt.Print("Type 'yes' to confirm: ")
 
@@ -135,7 +140,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	fmt.Printf("✓ Removed %d packages\n", len(packagesToRemove))
 
 	// Run autoremove if requested
-	if cleanupAutoremove {
+	if autoremove {
 		if err := mgr.AutoRemove(); err != nil {
 			return fmt.Errorf("failed to autoremove: %w", err)
 		}

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -85,10 +85,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("failed to add repository: %w", err)
 			}
 			state.AddRepository(sourcePath)
-			// pendingKeyPath is intentionally not cleared here so that consecutive
-			// deb lines can share the same GPG key. Note: it persists until the
-			// next "key" directive, so unrelated deb entries that appear after a
-			// key block will also inherit that key path.
+			pendingKeyPath = "" // Clear after consumption to avoid stale association
 			reposAdded = true
 		}
 	}

--- a/internal/commands/sync.go
+++ b/internal/commands/sync.go
@@ -46,15 +46,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 	}
 
 	// Run cleanup with force so removal actually happens (sync is not dry-run)
-	origForce := cleanupForce
-	origAutoremove := cleanupAutoremove
-	cleanupForce = true
-	cleanupAutoremove = syncAutoremove
-	defer func() {
-		cleanupForce = origForce
-		cleanupAutoremove = origAutoremove
-	}()
-	return runCleanup(cmd, args)
+	return doCleanup(true, false, syncAutoremove)
 }
 
 func runSyncDryRun() error {


### PR DESCRIPTION
Fixes all 6 issues from Section 1 (Correctness & Logic Bugs) of the Feb 20 code review.

- **check.go**: treat dpkg-query non-zero exit as not-installed instead of fatal error
- **repositories.go**: parse os-release key=value pairs with line boundaries to prevent false positives
- **install.go**: clear pendingKeyPath after consumption by a deb entry
- **sync.go / cleanup.go**: extract doCleanup with explicit parameters to avoid mutating globals
- **sources.go**: support multi-stanza DEB822 .sources files
- **sources.go**: use splitLines helper for consistent newline handling