### PR TITLE
fix: improve error handling in sources, packages, and keys

### DIFF
--- a/internal/apt/keys.go
+++ b/internal/apt/keys.go
@@ -131,20 +131,20 @@ func dearmorKey(data []byte) ([]byte, error) {
 	// Create a temp file for the armored key
 	tmpFile, err := os.CreateTemp("", "apt-bundle-key-*.asc")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create temp file for dearmor: %w", err)
 	}
 	defer os.Remove(tmpFile.Name())
 
 	if _, err := tmpFile.Write(data); err != nil {
 		tmpFile.Close()
-		return nil, err
+		return nil, fmt.Errorf("write armored key to temp file: %w", err)
 	}
 	tmpFile.Close()
 
 	// Create a temp file for the dearmored output
 	outFile, err := os.CreateTemp("", "apt-bundle-key-*.gpg")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create temp output file for dearmor: %w", err)
 	}
 	outPath := outFile.Name()
 	outFile.Close()

--- a/internal/apt/packages.go
+++ b/internal/apt/packages.go
@@ -128,7 +128,10 @@ func GetAllInstalledPackages() ([]string, error) {
 	}
 
 	// Split output by newlines and filter empty strings
-	lines := splitLines(string(output))
+	lines, err := splitLines(string(output))
+	if err != nil {
+		return nil, fmt.Errorf("parsing installed packages output: %w", err)
+	}
 	var packages []string
 	for _, line := range lines {
 		if line != "" {
@@ -140,11 +143,11 @@ func GetAllInstalledPackages() ([]string, error) {
 }
 
 // splitLines splits a string by newlines, handling both \n and \r\n
-func splitLines(s string) []string {
+func splitLines(s string) ([]string, error) {
 	var lines []string
 	sc := bufio.NewScanner(strings.NewReader(s))
 	for sc.Scan() {
 		lines = append(lines, sc.Text())
 	}
-	return lines
+	return lines, sc.Err()
 }

--- a/internal/apt/packages_test.go
+++ b/internal/apt/packages_test.go
@@ -91,7 +91,10 @@ func TestSplitLines(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := splitLines(tt.input)
+			got, err := splitLines(tt.input)
+			if err != nil {
+				t.Fatalf("splitLines() unexpected error: %v", err)
+			}
 			if len(got) != len(tt.want) {
 				t.Errorf("splitLines() got %d lines, want %d", len(got), len(tt.want))
 				return

--- a/internal/apt/sources.go
+++ b/internal/apt/sources.go
@@ -2,6 +2,8 @@ package apt
 
 import (
 	"bufio"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -82,7 +84,11 @@ func ListCustomSources(sourcesListPath, sourcesDir string) ([]SourceEntry, error
 	seen := make(map[string]bool)
 
 	// Read main sources.list
-	if data, err := os.ReadFile(sourcesListPath); err == nil {
+	data, err := os.ReadFile(sourcesListPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("reading %s: %w", sourcesListPath, err)
+	}
+	if err == nil {
 		lines := strings.Split(string(data), "\n")
 		for _, line := range lines {
 			if e, ok := parseDebLineToSource(line); ok && !seen[e.AptfileLine] {
@@ -91,7 +97,6 @@ func ListCustomSources(sourcesListPath, sourcesDir string) ([]SourceEntry, error
 			}
 		}
 	}
-	// Ignore read error (e.g. missing file)
 
 	// Read sources.list.d
 	dirEntries, err := os.ReadDir(sourcesDir)
@@ -110,7 +115,7 @@ func ListCustomSources(sourcesListPath, sourcesDir string) ([]SourceEntry, error
 		if strings.HasSuffix(name, ".list") {
 			listEntries, err := readListFile(path)
 			if err != nil {
-				continue
+				return nil, fmt.Errorf("reading %s: %w", path, err)
 			}
 			for _, e := range listEntries {
 				if !seen[e.AptfileLine] {
@@ -121,7 +126,7 @@ func ListCustomSources(sourcesListPath, sourcesDir string) ([]SourceEntry, error
 		} else {
 			sourceEntries, err := readDEB822File(path)
 			if err != nil {
-				continue
+				return nil, fmt.Errorf("reading %s: %w", path, err)
 			}
 			for _, e := range sourceEntries {
 				if !seen[e.AptfileLine] {


### PR DESCRIPTION
## Summary
- **sources.go**: Only ignore `os.ErrNotExist` when reading `sources.list` instead of swallowing all errors (e.g. permission denied). Propagate errors from `readListFile` and `readDEB822File` instead of silently continuing with `continue`.
- **packages.go**: Check `sc.Err()` after the `splitLines` scanner loop and return the error to callers. Updated `GetAllInstalledPackages` and test accordingly.
- **keys.go**: Wrap bare errors from `os.CreateTemp` and `tmpFile.Write` in `dearmorKey` with `fmt.Errorf` context.

Addresses code review section 4 (Error Handling).

## Testing
- `make test` passes (all existing tests pass with the updated `splitLines` signature)