### PR TITLE
docs: add godoc comments and fix misleading pendingKeyPath comment

### DIFF
--- a/internal/aptfile/parser.go
+++ b/internal/aptfile/parser.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// EntryType represents the kind of directive in an Aptfile (e.g. "apt", "ppa", "deb", "key").
+// EntryType represents the kind of directive in an Aptfile line (apt, ppa, deb, or key).
 type EntryType string
 
 const (
@@ -17,7 +17,9 @@ const (
 	EntryTypeKey EntryType = "key"
 )
 
-// Entry represents a single parsed line from an Aptfile.
+// Entry represents a single parsed directive from an Aptfile, including
+// the directive type, its argument value, the source line number, and
+// the original unparsed line text.
 type Entry struct {
 	Type     EntryType
 	Value    string
@@ -25,6 +27,8 @@ type Entry struct {
 	Original string
 }
 
+// Parse reads an Aptfile at the given path and returns the list of entries.
+// Blank lines and comment lines (starting with #) are skipped.
 func Parse(filePath string) ([]Entry, error) {
 	file, err := os.Open(filePath)
 	if err != nil {

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -85,7 +85,10 @@ func runInstall(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("failed to add repository: %w", err)
 			}
 			state.AddRepository(sourcePath)
-			// Keep pendingKeyPath for subsequent deb/deb-src lines from same repo
+			// pendingKeyPath is intentionally not cleared here so that consecutive
+			// deb lines can share the same GPG key. Note: it persists until the
+			// next "key" directive, so unrelated deb entries that appear after a
+			// key block will also inherit that key path.
 			reposAdded = true
 		}
 	}


### PR DESCRIPTION
## Summary
- Add godoc comments to exported `EntryType`, `Entry`, and `Parse` in `internal/aptfile/parser.go`
- Fix misleading comment at `install.go:90` that claimed `pendingKeyPath` was scoped to the same repo when there is no mechanism to reset it between repos

Addresses code review section 6 (Documentation & Comments) from `.local/cr/feb20.md`.