### PR TITLE
fix: deduplicate pkgVer and lock-file logic, document default command

### DIFF
--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -3,8 +3,6 @@ package commands
 import (
 	"fmt"
 	"os"
-	"sort"
-	"strings"
 
 	"github.com/apt-bundle/apt-bundle/internal/apt"
 	"github.com/apt-bundle/apt-bundle/internal/aptfile"
@@ -161,29 +159,11 @@ func runInstall(cmd *cobra.Command, args []string) error {
 }
 
 func writeLockFileFromPackages(packages []string) error {
-	type pkgVer struct {
-		pkg string
-		ver string
-	}
-	var locked []pkgVer
-	for _, pkg := range packages {
-		pkgName := aptfile.ExtractPkgName(pkg)
-		ver, err := mgr.GetInstalledVersion(pkgName)
-		if err != nil || ver == "" {
-			continue
-		}
-		locked = append(locked, pkgVer{pkg: pkgName, ver: ver})
-	}
+	locked, _ := resolveInstalledVersions(packages)
 	if len(locked) == 0 {
 		return nil
 	}
-	sort.Slice(locked, func(i, j int) bool { return locked[i].pkg < locked[j].pkg })
-	path := getLockFilePath()
-	var lines []string
-	for _, pv := range locked {
-		lines = append(lines, pv.pkg+"="+pv.ver)
-	}
-	return os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0644)
+	return writeLockFileEntries(locked)
 }
 
 func runInstallDryRun(entries []aptfile.Entry) error {

--- a/internal/commands/lock.go
+++ b/internal/commands/lock.go
@@ -11,6 +11,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// pkgVer holds a package name and its installed version for lock file entries.
+type pkgVer struct {
+	pkg string
+	ver string
+}
+
 var lockCmd = &cobra.Command{
 	Use:   "lock",
 	Short: "Generate Aptfile.lock from current installed versions of Aptfile packages",
@@ -45,35 +51,46 @@ func runLock(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no packages in Aptfile")
 	}
 
-	type pkgVer struct {
-		pkg string
-		ver string
-	}
-	var locked []pkgVer
-	for _, pkg := range packages {
-		pkgName := aptfile.ExtractPkgName(pkg)
-		ver, err := mgr.GetInstalledVersion(pkgName)
-		if err != nil || ver == "" {
-			fmt.Printf("Warning: %s not installed, skipping in lock file\n", pkgName)
-			continue
-		}
-		locked = append(locked, pkgVer{pkg: pkgName, ver: ver})
+	locked, skipped := resolveInstalledVersions(packages)
+	for _, name := range skipped {
+		fmt.Printf("Warning: %s not installed, skipping in lock file\n", name)
 	}
 	if len(locked) == 0 {
 		return fmt.Errorf("no installed packages from Aptfile to lock")
 	}
 
-	sort.Slice(locked, func(i, j int) bool { return locked[i].pkg < locked[j].pkg })
-	path := getLockFilePath()
-	var lines []string
-	for _, pv := range locked {
-		lines = append(lines, pv.pkg+"="+pv.ver)
-	}
-	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+	if err := writeLockFileEntries(locked); err != nil {
 		return fmt.Errorf("failed to write lock file: %w", err)
 	}
-	fmt.Printf("Wrote %d package versions to %s\n", len(locked), path)
+	fmt.Printf("Wrote %d package versions to %s\n", len(locked), getLockFilePath())
 	return nil
+}
+
+// resolveInstalledVersions queries the installed version of each package and
+// returns a sorted slice of pkgVer for packages with a known version, along
+// with the names of packages that were skipped (not installed or version unknown).
+func resolveInstalledVersions(packages []string) (locked []pkgVer, skipped []string) {
+	for _, pkg := range packages {
+		pkgName := aptfile.ExtractPkgName(pkg)
+		ver, err := mgr.GetInstalledVersion(pkgName)
+		if err != nil || ver == "" {
+			skipped = append(skipped, pkgName)
+			continue
+		}
+		locked = append(locked, pkgVer{pkg: pkgName, ver: ver})
+	}
+	sort.Slice(locked, func(i, j int) bool { return locked[i].pkg < locked[j].pkg })
+	return locked, skipped
+}
+
+// writeLockFileEntries writes the given package versions to Aptfile.lock.
+func writeLockFileEntries(entries []pkgVer) error {
+	path := getLockFilePath()
+	var lines []string
+	for _, pv := range entries {
+		lines = append(lines, pv.pkg+"="+pv.ver)
+	}
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0644)
 }
 
 // ReadLockFile returns package specs (pkg=version) from the lock file, or nil if missing/invalid

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -17,6 +17,9 @@ var (
 // mgr is the AptManager used by all commands.
 var mgr = apt.NewAptManager()
 
+// rootCmd is the base command for apt-bundle.
+// Note: rootCmd.RunE is set to runInstall by install.go's init() function,
+// making "install" the default command when apt-bundle is run with no subcommand.
 var rootCmd = &cobra.Command{
 	Use:   "apt-bundle",
 	Short: "A declarative package manager for apt",


### PR DESCRIPTION
## Summary
- Extract shared `resolveInstalledVersions` and `writeLockFileEntries` helpers in `lock.go` to eliminate the duplicated `pkgVer` struct and lock-file-writing logic that was copied between `install.go` and `lock.go`
- Add comment on `rootCmd` in `root.go` documenting that `RunE` is set to `runInstall` by `install.go`'s `init()`, making install the default command when no subcommand is given
- Addresses code review section 3 (Design & Architecture) items (a) and (b)

## Testing
- [x] `make test` passes with all existing tests
- [ ] Verify `apt-bundle install --lock` still writes Aptfile.lock correctly
- [ ] Verify `apt-bundle lock` still writes Aptfile.lock with warnings for missing packages