### PR TITLE
fix: add security validation for repo URIs and package names

### DIFF
--- a/internal/apt/packages.go
+++ b/internal/apt/packages.go
@@ -10,6 +10,25 @@ import (
 // dpkg status string for installed packages
 const dpkgStatusInstalled = "install ok installed"
 
+// packageNameRE validates Debian package names: must start with an alphanumeric,
+// followed by one or more alphanumerics, dots, plus signs, or hyphens.
+// See Debian Policy §5.6.1.
+var packageNameRE = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.+\-]+$`)
+
+// validatePackageName checks that a package spec (e.g. "curl" or "nano=2.9.3-2")
+// has a valid Debian package name. Version-pinned specs are split on "=" and
+// only the name portion is validated.
+func validatePackageName(spec string) error {
+	name := spec
+	if idx := strings.Index(spec, "="); idx > 0 {
+		name = spec[:idx]
+	}
+	if !packageNameRE.MatchString(name) {
+		return fmt.Errorf("invalid package name %q: must match Debian naming convention (alphanumeric start, alphanumerics/./+/- only, at least 2 chars)", name)
+	}
+	return nil
+}
+
 // CandidateVersionNone is the apt-cache policy output when no candidate version exists
 const CandidateVersionNone = "(none)"
 
@@ -30,6 +49,9 @@ func (m *AptManager) IsPackageInstalled(packageName string) (bool, error) {
 func (m *AptManager) InstallPackage(packageName string) error {
 	if packageName == "" {
 		return fmt.Errorf("package name cannot be empty")
+	}
+	if err := validatePackageName(packageName); err != nil {
+		return err
 	}
 	fmt.Printf("Installing package: %s\n", packageName)
 

--- a/internal/apt/packages_test.go
+++ b/internal/apt/packages_test.go
@@ -3,6 +3,7 @@ package apt
 import (
 	"errors"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/apt-bundle/apt-bundle/internal/testutil"
@@ -55,6 +56,39 @@ func TestIsPackageInstalled(t *testing.T) {
 	})
 }
 
+func TestValidatePackageName(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    string
+		wantErr bool
+	}{
+		{"valid simple", "curl", false},
+		{"valid with hyphen", "apt-get", false},
+		{"valid with dot", "libgcc1.0", false},
+		{"valid with plus", "g++", false},
+		{"valid version pinned", "nano=2.9.3-2", false},
+		{"valid mixed", "lib2to3", false},
+		{"invalid single char", "a", true},
+		{"invalid starts with hyphen", "-bad", true},
+		{"invalid starts with dot", ".bad", true},
+		{"invalid shell metachar", "pkg;rm -rf /", true},
+		{"invalid space", "pkg name", true},
+		{"invalid backtick", "pkg`cmd`", true},
+		{"invalid dollar", "pkg$var", true},
+		{"invalid pipe", "pkg|cat", true},
+		{"invalid ampersand", "pkg&&cmd", true},
+		{"invalid slash", "../etc/passwd", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePackageName(tt.spec)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validatePackageName(%q) error = %v, wantErr %v", tt.spec, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestInstallPackage(t *testing.T) {
 	t.Run("install without sudo", func(t *testing.T) {
 		m := NewAptManager()
@@ -69,6 +103,17 @@ func TestInstallPackage(t *testing.T) {
 		err := m.InstallPackage("")
 		if err == nil {
 			t.Error("InstallPackage('') should fail for empty package name")
+		}
+	})
+
+	t.Run("rejects invalid package name", func(t *testing.T) {
+		m := NewAptManager()
+		err := m.InstallPackage("pkg;rm -rf /")
+		if err == nil {
+			t.Error("InstallPackage should reject invalid package names")
+		}
+		if err != nil && !strings.Contains(err.Error(), "invalid package name") {
+			t.Errorf("Expected invalid package name error, got: %s", err.Error())
 		}
 	})
 }

--- a/internal/apt/repositories.go
+++ b/internal/apt/repositories.go
@@ -3,6 +3,7 @@ package apt
 import (
 	"crypto/sha256"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -44,6 +45,26 @@ func (m *AptManager) AddPPA(ppa string) error {
 
 	fmt.Printf("✓ PPA %s added successfully\n", ppa)
 	return nil
+}
+
+// validateRepoURI ensures the repository URI uses https://. Rejects http://, file://, and other schemes.
+func validateRepoURI(repoURI string) error {
+	u, err := url.Parse(repoURI)
+	if err != nil {
+		return fmt.Errorf("invalid repository URI: %w", err)
+	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		return fmt.Errorf("repository URI must use https://, not http:// (rejected for security)")
+	case "file":
+		return fmt.Errorf("file:// repository URIs are not allowed (rejected for security)")
+	case "":
+		return fmt.Errorf("invalid repository URI: missing scheme (use https://)")
+	default:
+		return fmt.Errorf("repository URI scheme %q not allowed; use https://", u.Scheme)
+	}
 }
 
 // DebRepository represents a parsed deb repository configuration
@@ -135,6 +156,11 @@ func parseDebLine(line string) (*DebRepository, error) {
 	}
 
 	repo.URIs = parts[0]
+
+	if err := validateRepoURI(repo.URIs); err != nil {
+		return nil, err
+	}
+
 	repo.Suites = parts[1]
 
 	if len(parts) > 2 {

--- a/internal/apt/repositories_test.go
+++ b/internal/apt/repositories_test.go
@@ -190,6 +190,56 @@ func TestParseDebLine(t *testing.T) {
 			t.Error("Expected error for empty deb line")
 		}
 	})
+
+	t.Run("rejects http URI", func(t *testing.T) {
+		_, err := parseDebLine("http://example.com/ubuntu jammy main")
+		if err == nil {
+			t.Fatal("Expected error for http:// URI")
+		}
+		if !strings.Contains(err.Error(), "not http://") {
+			t.Errorf("Expected http rejection message, got: %s", err.Error())
+		}
+	})
+
+	t.Run("rejects file URI", func(t *testing.T) {
+		_, err := parseDebLine("file:///local/repo jammy main")
+		if err == nil {
+			t.Fatal("Expected error for file:// URI")
+		}
+		if !strings.Contains(err.Error(), "file://") {
+			t.Errorf("Expected file:// rejection message, got: %s", err.Error())
+		}
+	})
+
+	t.Run("rejects ftp URI", func(t *testing.T) {
+		_, err := parseDebLine("ftp://example.com/ubuntu jammy main")
+		if err == nil {
+			t.Fatal("Expected error for ftp:// URI")
+		}
+		if !strings.Contains(err.Error(), "not allowed") {
+			t.Errorf("Expected scheme rejection message, got: %s", err.Error())
+		}
+	})
+
+	t.Run("rejects missing scheme", func(t *testing.T) {
+		_, err := parseDebLine("example.com/ubuntu jammy main")
+		if err == nil {
+			t.Fatal("Expected error for URI without scheme")
+		}
+		if !strings.Contains(err.Error(), "missing scheme") {
+			t.Errorf("Expected missing scheme message, got: %s", err.Error())
+		}
+	})
+
+	t.Run("accepts https URI", func(t *testing.T) {
+		repo, err := parseDebLine("https://example.com/ubuntu jammy main")
+		if err != nil {
+			t.Fatalf("Expected no error for https URI, got: %v", err)
+		}
+		if repo.URIs != "https://example.com/ubuntu" {
+			t.Errorf("Expected URI 'https://example.com/ubuntu', got '%s'", repo.URIs)
+		}
+	})
 }
 
 func TestDebRepositoryToDEB822(t *testing.T) {


### PR DESCRIPTION
Add URI scheme validation in parseDebLine to reject non-https schemes (http, file, ftp, etc.), matching the validation already done in keys.go for key URLs. Add package name validation against Debian naming convention (^[a-zA-Z0-9][a-zA-Z0-9.+\-]+$) in InstallPackage to prevent specially-crafted strings from reaching apt-get.

Addresses code review section 5 (Security) items.