### PR TITLE
fix: apt package layer improvements and install.go correctness

### DIFF
--- a/internal/apt/executor.go
+++ b/internal/apt/executor.go
@@ -11,8 +11,7 @@ var _ Executor = (*realExecutor)(nil)
 
 func (e *realExecutor) Run(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
-	cmd.Stdout = nil
-	cmd.Stderr = nil
+	// stdout and stderr are nil by default — command output goes to /dev/null
 	return cmd.Run()
 }
 

--- a/internal/apt/keys.go
+++ b/internal/apt/keys.go
@@ -154,7 +154,7 @@ func (m *AptManager) dearmorKey(data []byte) ([]byte, error) {
 }
 
 // RemoveGPGKey removes a GPG key file
-func RemoveGPGKey(keyPath string) error {
+func (m *AptManager) RemoveGPGKey(keyPath string) error {
 	if err := os.Remove(keyPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove key: %w", err)
 	}

--- a/internal/apt/keys_test.go
+++ b/internal/apt/keys_test.go
@@ -120,6 +120,7 @@ mQINBF...
 
 func TestRemoveGPGKey(t *testing.T) {
 	tmpDir := t.TempDir()
+	m := &AptManager{}
 
 	t.Run("remove existing key", func(t *testing.T) {
 		keyPath := filepath.Join(tmpDir, "test.gpg")
@@ -127,7 +128,7 @@ func TestRemoveGPGKey(t *testing.T) {
 			t.Fatalf("Failed to create test file: %v", err)
 		}
 
-		err := RemoveGPGKey(keyPath)
+		err := m.RemoveGPGKey(keyPath)
 		if err != nil {
 			t.Errorf("RemoveGPGKey failed: %v", err)
 		}
@@ -138,7 +139,7 @@ func TestRemoveGPGKey(t *testing.T) {
 	})
 
 	t.Run("remove nonexistent key", func(t *testing.T) {
-		err := RemoveGPGKey(filepath.Join(tmpDir, "nonexistent.gpg"))
+		err := m.RemoveGPGKey(filepath.Join(tmpDir, "nonexistent.gpg"))
 		if err != nil {
 			t.Errorf("RemoveGPGKey should not error for nonexistent file: %v", err)
 		}

--- a/internal/apt/manager.go
+++ b/internal/apt/manager.go
@@ -22,6 +22,8 @@ type AptManager struct {
 	LookPath      func(string) (string, error)
 	OsReleasePath string
 	StatePath     func() string
+	SourcesDir    string
+	SourcesPrefix string
 }
 
 // NewAptManager creates an AptManager with production defaults.
@@ -33,5 +35,7 @@ func NewAptManager() *AptManager {
 		LookPath:      exec.LookPath,
 		OsReleasePath: "/etc/os-release",
 		StatePath:     func() string { return filepath.Join(StateDir, StateFile) },
+		SourcesDir:    SourcesDir,
+		SourcesPrefix: SourcesPrefix,
 	}
 }

--- a/internal/apt/packages.go
+++ b/internal/apt/packages.go
@@ -13,7 +13,7 @@ const dpkgStatusInstalled = "install ok installed"
 // packageNameRE validates Debian package names: must start with an alphanumeric,
 // followed by one or more alphanumerics, dots, plus signs, or hyphens.
 // See Debian Policy §5.6.1.
-var packageNameRE = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.+\-]+$`)
+var packageNameRE = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.+-]+$`)
 
 // validatePackageName checks that a package spec (e.g. "curl" or "nano=2.9.3-2")
 // has a valid Debian package name. Version-pinned specs are split on "=" and

--- a/internal/apt/repositories.go
+++ b/internal/apt/repositories.go
@@ -17,6 +17,12 @@ const (
 	SourcesPrefix = "apt-bundle-"
 )
 
+// optionsRegex matches bracketed options in a deb line, e.g. [arch=amd64]
+var optionsRegex = regexp.MustCompile(`^\[([^\]]+)\]\s*`)
+
+// archRegex extracts the arch= value from bracketed options
+var archRegex = regexp.MustCompile(`arch=([^\s]+)`)
+
 // isUbuntu checks if the current system is Ubuntu by reading /etc/os-release.
 // Parses key=value pairs properly to avoid false positives from fields like
 // PRETTY_NAME or derivative distro IDs.
@@ -97,7 +103,7 @@ type DebRepository struct {
 
 // AddDebRepository adds a deb repository in DEB822 format to /etc/apt/sources.list.d/
 // keyPath is optional - if provided, it will be used for the Signed-By field
-func AddDebRepository(repoLine string, keyPath string) (string, error) {
+func (m *AptManager) AddDebRepository(repoLine string, keyPath string) (string, error) {
 	fmt.Printf("Adding deb repository: %s\n", repoLine)
 
 	repo, err := parseDebLine(repoLine)
@@ -112,8 +118,8 @@ func AddDebRepository(repoLine string, keyPath string) (string, error) {
 
 	// Generate filename from repo hash
 	hash := sha256.Sum256([]byte(repoLine))
-	filename := fmt.Sprintf("%s%x.sources", SourcesPrefix, hash[:8])
-	sourcePath := filepath.Join(SourcesDir, filename)
+	filename := fmt.Sprintf("%s%x.sources", m.SourcesPrefix, hash[:8])
+	sourcePath := filepath.Join(m.SourcesDir, filename)
 
 	// Check if source already exists (idempotency)
 	if _, err := os.Stat(sourcePath); err == nil {
@@ -122,7 +128,7 @@ func AddDebRepository(repoLine string, keyPath string) (string, error) {
 	}
 
 	// Ensure the sources directory exists
-	if err := os.MkdirAll(SourcesDir, 0755); err != nil {
+	if err := os.MkdirAll(m.SourcesDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create sources directory: %w", err)
 	}
 
@@ -155,13 +161,11 @@ func parseDebLine(line string) (*DebRepository, error) {
 	}
 
 	// Extract options in brackets [key=value key2=value2]
-	optionsRegex := regexp.MustCompile(`^\[([^\]]+)\]\s*`)
 	if matches := optionsRegex.FindStringSubmatch(line); len(matches) > 1 {
 		options := matches[1]
 		line = optionsRegex.ReplaceAllString(line, "")
 
 		// Parse arch option
-		archRegex := regexp.MustCompile(`arch=([^\s]+)`)
 		if archMatches := archRegex.FindStringSubmatch(options); len(archMatches) > 1 {
 			repo.Architectures = archMatches[1]
 		}
@@ -212,7 +216,7 @@ func (r *DebRepository) ToDEB822() string {
 }
 
 // RemoveDebRepository removes a sources file
-func RemoveDebRepository(sourcePath string) error {
+func (m *AptManager) RemoveDebRepository(sourcePath string) error {
 	if err := os.Remove(sourcePath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove sources file: %w", err)
 	}

--- a/internal/apt/repositories_test.go
+++ b/internal/apt/repositories_test.go
@@ -342,9 +342,14 @@ func TestAddDebRepository(t *testing.T) {
 			t.Fatalf("Failed to create fake key file: %v", err)
 		}
 
+		m := &AptManager{
+			SourcesDir:    tmpDir,
+			SourcesPrefix: "apt-bundle-",
+		}
+
 		// This will fail without write permissions to /etc/apt/sources.list.d
 		// but we can verify it doesn't panic and handles the error
-		_, err := AddDebRepository(repoLine, keyPath)
+		_, err := m.AddDebRepository(repoLine, keyPath)
 		if err != nil {
 			// Expected to fail in test environment
 			t.Logf("AddDebRepository failed (expected in test): %v", err)
@@ -354,6 +359,7 @@ func TestAddDebRepository(t *testing.T) {
 
 func TestRemoveDebRepository(t *testing.T) {
 	tmpDir := t.TempDir()
+	m := &AptManager{}
 
 	t.Run("remove existing source", func(t *testing.T) {
 		sourcePath := filepath.Join(tmpDir, "test.sources")
@@ -361,7 +367,7 @@ func TestRemoveDebRepository(t *testing.T) {
 			t.Fatalf("Failed to create test file: %v", err)
 		}
 
-		err := RemoveDebRepository(sourcePath)
+		err := m.RemoveDebRepository(sourcePath)
 		if err != nil {
 			t.Errorf("RemoveDebRepository failed: %v", err)
 		}
@@ -372,7 +378,7 @@ func TestRemoveDebRepository(t *testing.T) {
 	})
 
 	t.Run("remove nonexistent source", func(t *testing.T) {
-		err := RemoveDebRepository(filepath.Join(tmpDir, "nonexistent.sources"))
+		err := m.RemoveDebRepository(filepath.Join(tmpDir, "nonexistent.sources"))
 		if err != nil {
 			t.Errorf("RemoveDebRepository should not error for nonexistent file: %v", err)
 		}

--- a/internal/apt/sources.go
+++ b/internal/apt/sources.go
@@ -11,7 +11,10 @@ import (
 	"strings"
 )
 
-// SourcesListPath is the path to the main sources.list (overridable for testing)
+// SourcesListPath is the path to the main apt sources.list file.
+// It is exported as a package-level variable solely to allow test
+// overrides; production code should not modify it. Prefer passing
+// the path explicitly to ListCustomSources.
 var SourcesListPath = "/etc/apt/sources.list"
 
 // SourceEntry represents one repository line to emit in an Aptfile
@@ -89,7 +92,10 @@ func ListCustomSources(sourcesListPath, sourcesDir string) ([]SourceEntry, error
 		return nil, fmt.Errorf("reading %s: %w", sourcesListPath, err)
 	}
 	if err == nil {
-		lines, _ := splitLines(string(data))
+		lines, scanErr := splitLines(string(data))
+		if scanErr != nil {
+			return nil, fmt.Errorf("scanning %s: %w", sourcesListPath, scanErr)
+		}
 		for _, line := range lines {
 			if e, ok := parseDebLineToSource(line); ok && !seen[e.AptfileLine] {
 				seen[e.AptfileLine] = true
@@ -171,7 +177,10 @@ func readDEB822File(path string) ([]SourceEntry, error) {
 		return nil, err
 	}
 
-	lines, _ := splitLines(string(data))
+	lines, err := splitLines(string(data))
+	if err != nil {
+		return nil, fmt.Errorf("scanning %s: %w", path, err)
+	}
 	var entries []SourceEntry
 	var stanzaLines []string
 
@@ -199,6 +208,8 @@ func readDEB822File(path string) ([]SourceEntry, error) {
 }
 
 // parseDEB822Stanza parses a single DEB822 stanza (key-value pairs) into a SourceEntry.
+// Note: composite "Types: deb deb-src" is not yet handled; such stanzas
+// are treated as "deb" only. TODO: handle "deb deb-src" correctly.
 func parseDEB822Stanza(lines []string) (SourceEntry, bool) {
 	var types, uris, suites, components, architectures string
 	for _, line := range lines {

--- a/internal/apt/state.go
+++ b/internal/apt/state.go
@@ -2,6 +2,8 @@ package apt
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -40,15 +42,15 @@ func (m *AptManager) LoadState() (*State, error) {
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return NewState(), nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("load state from %s: %w", path, err)
 	}
 
 	var state State
 	if err := json.Unmarshal(data, &state); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("load state from %s: %w", path, err)
 	}
 
 	return &state, nil
@@ -61,7 +63,7 @@ func (m *AptManager) SaveState(s *State) error {
 	// Ensure the directory exists
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return err
+		return fmt.Errorf("create state directory %s: %w", dir, err)
 	}
 
 	data, err := json.MarshalIndent(s, "", "  ")
@@ -69,7 +71,10 @@ func (m *AptManager) SaveState(s *State) error {
 		return err
 	}
 
-	return os.WriteFile(path, data, 0644)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("write state file %s: %w", path, err)
+	}
+	return nil
 }
 
 // AddPackage adds a package to the state if not already present

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -57,6 +58,13 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to load state: %w", err)
 	}
+	// Persist state on exit regardless of success or failure so partially
+	// completed installs (keys/repos already added) are not orphaned.
+	defer func() {
+		if saveErr := mgr.SaveState(state); saveErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to save state: %v\n", saveErr)
+		}
+	}()
 
 	var pendingKeyPath string
 	var reposAdded bool
@@ -75,10 +83,11 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			if err := mgr.AddPPA(entry.Value); err != nil {
 				return fmt.Errorf("failed to add PPA: %w", err)
 			}
+			pendingKeyPath = "" // Clear: PPA manages its own keys; don't leak to next deb entry
 			reposAdded = true
 
 		case aptfile.EntryTypeDeb:
-			sourcePath, err := apt.AddDebRepository(entry.Value, pendingKeyPath)
+			sourcePath, err := mgr.AddDebRepository(entry.Value, pendingKeyPath)
 			if err != nil {
 				return fmt.Errorf("failed to add repository: %w", err)
 			}
@@ -88,14 +97,12 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if reposAdded || !noUpdate {
-		if !noUpdate {
-			if err := mgr.Update(); err != nil {
-				return fmt.Errorf("failed to update package lists: %w", err)
-			}
-		} else if reposAdded {
-			fmt.Println("⚠️  Warning: Repositories were added; run without --no-update to fetch package lists.")
+	if !noUpdate {
+		if err := mgr.Update(); err != nil {
+			return fmt.Errorf("failed to update package lists: %w", err)
 		}
+	} else if reposAdded {
+		fmt.Println("⚠️  Warning: Repositories were added; run without --no-update to fetch package lists.")
 	}
 
 	packagesToInstall := []string{}
@@ -141,11 +148,6 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		fmt.Println("No packages to install")
 	}
 
-	// Save the updated state
-	if err := mgr.SaveState(state); err != nil {
-		return fmt.Errorf("failed to save state: %w", err)
-	}
-
 	if installLock && len(packagesToInstall) > 0 {
 		if err := writeLockFileFromPackages(packagesToInstall); err != nil {
 			return fmt.Errorf("failed to write lock file: %w", err)
@@ -156,6 +158,8 @@ func runInstall(cmd *cobra.Command, args []string) error {
 }
 
 func writeLockFileFromPackages(packages []string) error {
+	// The skipped-packages list is intentionally dropped here; unlike the
+	// standalone lock command, install --lock does not warn about uninstalled packages.
 	locked, _ := resolveInstalledVersions(packages)
 	if len(locked) == 0 {
 		return nil
@@ -178,7 +182,7 @@ func runInstallDryRun(entries []aptfile.Entry) error {
 		switch entry.Type {
 		case aptfile.EntryTypeKey:
 			keyPath := mgr.KeyPathForURL(entry.Value)
-			if _, err := os.Stat(keyPath); os.IsNotExist(err) {
+			if _, err := os.Stat(keyPath); errors.Is(err, os.ErrNotExist) {
 				wouldAddKeys = append(wouldAddKeys, entry.Value)
 			}
 		case aptfile.EntryTypePPA:


### PR DESCRIPTION
## Summary

- Move `optionsRegex`/`archRegex` to package-level vars in `repositories.go` (avoid recompiling on every call)
- Convert `AddDebRepository`, `RemoveDebRepository`, and `RemoveGPGKey` from package functions to `*AptManager` methods; add `SourcesDir`/`SourcesPrefix` fields to `AptManager`
- Fix state file mode: `0644` → `0600` (owner-only; state file contains repo/key paths)
- Wrap bare errors in `state.go` with context wrapping for load/save failures
- Propagate `splitLines` scanner errors in `sources.go` instead of silently discarding with `_`
- Fix hyphen placement in `packageNameRE` regex (`\-` → `-` at end of character class)
- Remove redundant `cmd.Stdout = nil` / `cmd.Stderr = nil` in `executor.go`
- **[CRITICAL]** Defer `SaveState` after `LoadState` in `install.go` so partial runs (keys/repos added, package install fails) are not orphaned in state
- Fix `pendingKeyPath` not cleared on PPA entry (next `deb` line would inherit unrelated key)
- Remove redundant outer `if reposAdded || \!noUpdate` condition in `install.go`

## Addresses

Code review findings: §1 Correctness (critical + warning), §2 Idiomatic Go (3 nits), §3 Design (warnings), §4 Error Handling (warnings), §5 Security (warning), §6 Documentation (nit)

## Verification

```
go test ./...   # passes (non-root, mock-based)
go build ./...  # clean
go vet ./...    # clean
```