### PR TITLE
fix: commands correctness — sync dry-run, check, cleanup, lock

### DIFF
--- a/internal/commands/check.go
+++ b/internal/commands/check.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -72,8 +73,12 @@ func doCheck(aptFilePath string) (ok bool, missing []string, entries []aptfile.E
 
 		case aptfile.EntryTypeKey:
 			keyPath := mgr.KeyPathForURL(entry.Value)
-			if _, err := os.Stat(keyPath); os.IsNotExist(err) {
-				missing = append(missing, "key "+entry.Value)
+			if _, statErr := os.Stat(keyPath); statErr != nil {
+				if errors.Is(statErr, os.ErrNotExist) {
+					missing = append(missing, "key "+entry.Value)
+				} else {
+					return false, nil, nil, fmt.Errorf("checking key %s: %w", entry.Value, statErr)
+				}
 			}
 		}
 	}

--- a/internal/commands/cleanup.go
+++ b/internal/commands/cleanup.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/apt-bundle/apt-bundle/internal/apt"
 	"github.com/apt-bundle/apt-bundle/internal/aptfile"
 	"github.com/spf13/cobra"
 )
@@ -62,6 +63,7 @@ func doCleanup(force, zap, autoremove bool) error {
 	aptfilePackages := extractPackageNames(entries)
 
 	var packagesToRemove []string
+	var cachedState *apt.State // reused below to avoid a second LoadState in non-zap mode
 
 	if zap {
 		// Zap mode: remove ALL packages not in Aptfile
@@ -71,7 +73,7 @@ func doCleanup(force, zap, autoremove bool) error {
 		}
 	} else {
 		// Normal mode: only remove packages tracked by apt-bundle
-		packagesToRemove, err = getPackagesToCleanup(aptfilePackages)
+		packagesToRemove, cachedState, err = getPackagesToCleanup(aptfilePackages)
 		if err != nil {
 			return err
 		}
@@ -116,10 +118,15 @@ func doCleanup(force, zap, autoremove bool) error {
 		}
 	}
 
-	// Load state for updating after removal
-	state, err := mgr.LoadState()
-	if err != nil {
-		return fmt.Errorf("failed to load state: %w", err)
+	// Reuse state already loaded by getPackagesToCleanup in non-zap mode.
+	var state *apt.State
+	if cachedState != nil {
+		state = cachedState
+	} else {
+		state, err = mgr.LoadState()
+		if err != nil {
+			return fmt.Errorf("failed to load state: %w", err)
+		}
 	}
 
 	// Remove packages
@@ -166,14 +173,15 @@ func extractPackageNames(entries []aptfile.Entry) []string {
 	return names
 }
 
-// getPackagesToCleanup returns packages that were installed by apt-bundle but are no longer in Aptfile
-func getPackagesToCleanup(aptfilePackages []string) ([]string, error) {
+// getPackagesToCleanup returns packages that were installed by apt-bundle but are no longer in Aptfile,
+// along with the loaded State so the caller can reuse it without a second LoadState call.
+func getPackagesToCleanup(aptfilePackages []string) ([]string, *apt.State, error) {
 	state, err := mgr.LoadState()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load state: %w", err)
+		return nil, nil, fmt.Errorf("failed to load state: %w", err)
 	}
 
-	return state.GetPackagesNotIn(aptfilePackages), nil
+	return state.GetPackagesNotIn(aptfilePackages), state, nil
 }
 
 // getPackagesToZap returns ALL manually installed packages that are not in Aptfile

--- a/internal/commands/cleanup_test.go
+++ b/internal/commands/cleanup_test.go
@@ -448,7 +448,7 @@ func TestGetPackagesToCleanup(t *testing.T) {
 	}
 
 	t.Run("some packages to remove", func(t *testing.T) {
-		toRemove, err := getPackagesToCleanup([]string{"vim", "curl"})
+		toRemove, _, err := getPackagesToCleanup([]string{"vim", "curl"})
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -458,7 +458,7 @@ func TestGetPackagesToCleanup(t *testing.T) {
 	})
 
 	t.Run("no packages to remove", func(t *testing.T) {
-		toRemove, err := getPackagesToCleanup([]string{"vim", "curl", "git", "htop"})
+		toRemove, _, err := getPackagesToCleanup([]string{"vim", "curl", "git", "htop"})
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -468,7 +468,7 @@ func TestGetPackagesToCleanup(t *testing.T) {
 	})
 
 	t.Run("all packages to remove", func(t *testing.T) {
-		toRemove, err := getPackagesToCleanup([]string{})
+		toRemove, _, err := getPackagesToCleanup([]string{})
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}

--- a/internal/commands/lock.go
+++ b/internal/commands/lock.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"bufio"
+	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -98,14 +101,15 @@ func ReadLockFile() ([]string, error) {
 	path := getLockFilePath()
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, fmt.Errorf("lock file not found: %s (run 'apt-bundle lock' first)", path)
 		}
 		return nil, err
 	}
 	var specs []string
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
@@ -113,6 +117,9 @@ func ReadLockFile() ([]string, error) {
 		if pkg, ver, ok := strings.Cut(line, "="); ok && pkg != "" && ver != "" {
 			specs = append(specs, line)
 		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("reading lock file %s: %w", path, err)
 	}
 	return specs, nil
 }

--- a/internal/commands/sync.go
+++ b/internal/commands/sync.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/apt-bundle/apt-bundle/internal/apt"
 	"github.com/apt-bundle/apt-bundle/internal/aptfile"
@@ -57,9 +59,21 @@ func runSyncDryRun() error {
 
 	// What would install do
 	fmt.Printf("Reading Aptfile from: %s (dry-run)\n", aptfilePath)
-	wouldInstall, wouldRemove, err := syncDryRunPlan(entries)
+	wouldInstall, wouldRemove, wouldAddKeys, wouldAddRepos, err := syncDryRunPlan(entries)
 	if err != nil {
 		return fmt.Errorf("sync dry-run: %w", err)
+	}
+	if len(wouldAddKeys) > 0 {
+		fmt.Println("--- would add keys ---")
+		for _, k := range wouldAddKeys {
+			fmt.Printf("  %s\n", k)
+		}
+	}
+	if len(wouldAddRepos) > 0 {
+		fmt.Println("--- would add repositories ---")
+		for _, r := range wouldAddRepos {
+			fmt.Printf("  %s\n", r)
+		}
 	}
 	if len(wouldInstall) > 0 {
 		fmt.Println("--- would install ---")
@@ -73,21 +87,21 @@ func runSyncDryRun() error {
 			fmt.Printf("  %s\n", p)
 		}
 	}
-	if len(wouldInstall) == 0 && len(wouldRemove) == 0 {
+	if len(wouldInstall) == 0 && len(wouldRemove) == 0 && len(wouldAddKeys) == 0 && len(wouldAddRepos) == 0 {
 		fmt.Println("Nothing to do; system matches Aptfile.")
 	}
 	return nil
 }
 
-// syncDryRunPlan returns packages that would be installed and that would be removed
-func syncDryRunPlan(entries []aptfile.Entry) (wouldInstall, wouldRemove []string, err error) {
+// syncDryRunPlan returns what a sync would do: packages/repos/keys to add, and packages to remove.
+func syncDryRunPlan(entries []aptfile.Entry) (wouldInstall, wouldRemove, wouldAddKeys, wouldAddRepos []string, err error) {
 	state, err := mgr.LoadState()
 	if err != nil {
-		return nil, nil, fmt.Errorf("load state: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("load state: %w", err)
 	}
 	sources, err := apt.ListCustomSources(apt.SourcesListPath, apt.SourcesDir)
 	if err != nil {
-		return nil, nil, fmt.Errorf("list sources: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("list sources: %w", err)
 	}
 	sourceLines := make(map[string]bool)
 	for _, e := range sources {
@@ -96,15 +110,30 @@ func syncDryRunPlan(entries []aptfile.Entry) (wouldInstall, wouldRemove []string
 
 	aptfilePackages := extractPackageNames(entries)
 	for _, entry := range entries {
-		if entry.Type != aptfile.EntryTypeApt {
-			continue
-		}
-		pkgName := aptfile.ExtractPkgName(entry.Value)
-		installed, err := mgr.IsPackageInstalled(pkgName)
-		if err != nil || !installed {
-			wouldInstall = append(wouldInstall, entry.Value)
+		switch entry.Type {
+		case aptfile.EntryTypeKey:
+			keyPath := mgr.KeyPathForURL(entry.Value)
+			if _, statErr := os.Stat(keyPath); errors.Is(statErr, os.ErrNotExist) {
+				wouldAddKeys = append(wouldAddKeys, entry.Value)
+			}
+		case aptfile.EntryTypePPA:
+			line := "ppa " + entry.Value
+			if !sourceLines[line] {
+				wouldAddRepos = append(wouldAddRepos, line)
+			}
+		case aptfile.EntryTypeDeb:
+			line := "deb " + entry.Value
+			if !sourceLines[line] {
+				wouldAddRepos = append(wouldAddRepos, line)
+			}
+		case aptfile.EntryTypeApt:
+			pkgName := aptfile.ExtractPkgName(entry.Value)
+			installed, instErr := mgr.IsPackageInstalled(pkgName)
+			if instErr != nil || !installed {
+				wouldInstall = append(wouldInstall, entry.Value)
+			}
 		}
 	}
 	wouldRemove = state.GetPackagesNotIn(aptfilePackages)
-	return wouldInstall, wouldRemove, nil
+	return wouldInstall, wouldRemove, wouldAddKeys, wouldAddRepos, nil
 }


### PR DESCRIPTION
## Summary

- **sync.go**: Extend `syncDryRunPlan` to cover `key`, `ppa`, and `deb` entries (previously only `apt` entries were reported in `sync --dry-run` output); updated return signature to include `wouldAddKeys`/`wouldAddRepos`
- **check.go**: Surface non-`ErrNotExist` `os.Stat` errors for key files (previously `permission denied` was silently treated as "key present")
- **cleanup.go**: Eliminate double `LoadState` — return `*apt.State` from `getPackagesToCleanup` and reuse it in `doCleanup`
- **lock.go**: Replace `strings.Split(..., "\n")` with `bufio.Scanner` for correct `\r\n` handling and scanner error propagation; `errors.Is(err, os.ErrNotExist)`

## Addresses

Code review findings: §1 Correctness (3 warnings), §2 Idiomatic Go (2 nits)

## Verification

```
go test ./...   # passes (non-root, mock-based)
go build ./...  # clean
go vet ./...    # clean
```

Depends on: #59 (must merge first — uses `*apt.State` return type from `getPackagesToCleanup`)