### PR TITLE
examples: add example 5 for Aptfile.lock reproducible builds

### DIFF
--- a/examples/5-with-lockfile/Aptfile
+++ b/examples/5-with-lockfile/Aptfile
@@ -1,0 +1,7 @@
+# Packages for a typical CI environment
+# After changing this file, regenerate the lock file:
+#   apt-bundle lock --file Aptfile
+apt curl
+apt git
+apt "jq=1.6-2.1ubuntu3"
+apt ca-certificates

--- a/examples/5-with-lockfile/Aptfile.lock
+++ b/examples/5-with-lockfile/Aptfile.lock
@@ -1,0 +1,4 @@
+ca-certificates=20230311ubuntu0.22.04.1
+curl=7.81.0-1ubuntu1.16
+git=1:2.34.1-1ubuntu1.11
+jq=1.6-2.1ubuntu3

--- a/examples/5-with-lockfile/Dockerfile
+++ b/examples/5-with-lockfile/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:22.04
+
+ARG APT_BUNDLE_REPO_ENTRY="deb [arch=amd64,arm64,armhf,i386 trusted=yes] https://apt-bundle.org/repo/ stable main"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install prerequisites and apt-bundle from APT repository
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates && \
+    echo "$APT_BUNDLE_REPO_ENTRY" | tee /etc/apt/sources.list.d/apt-bundle.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends apt-bundle && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy both Aptfile and Aptfile.lock so exact versions can be reproduced
+COPY Aptfile Aptfile.lock /app/
+WORKDIR /app
+
+# --locked installs the exact versions recorded in Aptfile.lock
+RUN apt-bundle install --file /app/Aptfile --locked
+
+CMD ["/bin/bash"]

--- a/examples/5-with-lockfile/Makefile
+++ b/examples/5-with-lockfile/Makefile
@@ -1,0 +1,35 @@
+IMAGE_NAME ?= with-lockfile
+IMAGE_TAG ?= latest
+DOCKERFILE ?= Dockerfile
+
+.DEFAULT_GOAL := help
+
+.PHONY: help build run test shell clean
+
+help: ## Show this help message
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Variables:"
+	@echo "  IMAGE_NAME  Docker image name (default: $(IMAGE_NAME))"
+	@echo "  IMAGE_TAG   Docker image tag (default: $(IMAGE_TAG))"
+	@echo "  DOCKERFILE  Dockerfile to use (default: $(DOCKERFILE))"
+	@echo ""
+
+build: ## Build the Docker image
+	docker build -f $(DOCKERFILE) -t $(IMAGE_NAME):$(IMAGE_TAG) .
+
+run: ## Run the container interactively
+	docker run -it $(IMAGE_NAME):$(IMAGE_TAG)
+
+test: ## Test that packages were installed at the locked versions
+	docker run --rm $(IMAGE_NAME):$(IMAGE_TAG) bash -c "curl --version && echo '---' && git --version && echo '---' && jq --version"
+	@echo "Verify that curl, git, and jq versions are displayed above (separated by ---)."
+
+shell: ## Open an interactive shell in the container
+	docker run -it $(IMAGE_NAME):$(IMAGE_TAG) /bin/bash
+
+clean: ## Remove the Docker image
+	docker rmi $(IMAGE_NAME):$(IMAGE_TAG) || true

--- a/examples/5-with-lockfile/README.md
+++ b/examples/5-with-lockfile/README.md
@@ -1,0 +1,80 @@
+# Reproducible Builds with Aptfile.lock
+
+This example demonstrates the lock file workflow for fully reproducible package installations.
+
+## The Problem
+
+Without a lock file, `apt curl` installs whatever version is current in the APT index.
+Two builds a week apart may get different patch versions, making debugging harder and
+builds less reproducible.
+
+## The Solution: Aptfile.lock
+
+`apt-bundle` provides a two-phase workflow:
+
+### Phase 1: Generate the lock file (on your dev machine or in CI)
+
+```bash
+# Install packages as usual
+sudo apt-bundle install
+
+# Snapshot the exact installed versions into Aptfile.lock
+apt-bundle lock
+```
+
+Commit both `Aptfile` and `Aptfile.lock` to version control.
+
+### Phase 2: Reproducible install (in Docker or on another machine)
+
+```bash
+# Install the exact versions from Aptfile.lock
+sudo apt-bundle install --locked
+```
+
+If a package in `Aptfile.lock` is not available at that exact version, the install fails
+loudly — rather than silently installing a different version.
+
+## What's in This Example
+
+- **`Aptfile`** — Declares dependencies; one package is pinned directly (`jq=1.6-2.1ubuntu3`)
+  and others are floating. Comments remind you to regenerate the lock file after changes.
+- **`Aptfile.lock`** — Committed snapshot of exact versions (`name=version`, one per line,
+  sorted alphabetically).
+- **`Dockerfile`** — Copies both files and runs `apt-bundle install --locked` so the image
+  always gets exactly the versions recorded in the lock file.
+
+## Updating the Lock File
+
+When you add, remove, or upgrade a package in `Aptfile`:
+
+```bash
+# Install to pick up the changes
+sudo apt-bundle install
+
+# Re-snapshot
+apt-bundle lock
+
+# Commit both files together
+git add Aptfile Aptfile.lock
+git commit -m "chore: update dependencies"
+```
+
+## Usage
+
+```bash
+# Build the image
+make build
+
+# Run interactively
+make run
+
+# Verify installed versions
+make test
+```
+
+## When to Use This Pattern
+
+- **CI/CD pipelines** — Guarantee identical packages on every run
+- **Team environments** — Every developer gets the same package versions
+- **Production Docker images** — Eliminate version drift between builds
+- **Audit requirements** — Keep an explicit, reviewable record of installed versions


### PR DESCRIPTION
Adds `examples/5-with-lockfile/` — a new self-contained example demonstrating the `Aptfile.lock` workflow.

Shows the complete two-phase pattern: generate a lock file with `apt-bundle lock`, commit it alongside `Aptfile`, then use `apt-bundle install --locked` in Docker/CI to reproduce exact package versions.

Files added:
- `Aptfile` — floating packages plus one pinned version (`jq=1.6-2.1ubuntu3`)
- `Aptfile.lock` — committed snapshot of exact versions (name=version, sorted)
- `Dockerfile` — copies both files and runs `apt-bundle install --locked`
- `Makefile` — build/run/test/shell/clean targets
- `README.md` — explains the two-phase workflow and when to use it

`Aptfile.lock` support landed after the original four examples were written. Without a concrete example the feature is hard to discover and the generate-locally/use-in-CI workflow is not obvious from the docs alone.

Verified: `make lint vet test` passes in this worktree (all Go tests pass, lint clean).