### PR TITLE
examples: add key+deb pattern to example 3 and update top-level README

### DIFF
--- a/examples/3-via-apt-get/Aptfile
+++ b/examples/3-via-apt-get/Aptfile
@@ -1,4 +1,12 @@
-# Minimal example demonstrating APT repository installation
+# CI/CD tool dependencies
+
+# Standard utilities
 apt curl
 apt git
 apt jq
+
+# Docker CLI - installed from Docker's official repository
+# 'key' downloads the GPG key; the following 'deb' is automatically signed by it
+key https://download.docker.com/linux/ubuntu/gpg
+deb "[arch=amd64] https://download.docker.com/linux/ubuntu jammy stable"
+apt docker-ce-cli

--- a/examples/3-via-apt-get/Dockerfile.traditional
+++ b/examples/3-via-apt-get/Dockerfile.traditional
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install build tools and utilities manually
+# Install standard utilities
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         curl \
@@ -11,9 +11,25 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Set working directory
+# Add Docker's official GPG key and repository manually
+# (apt-bundle handles all of this with two lines: key + deb)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gnupg && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+        gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    chmod a+r /etc/apt/keyrings/docker.gpg && \
+    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] \
+        https://download.docker.com/linux/ubuntu jammy stable" | \
+        tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        docker-ce-cli && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /workspace
 
-# Default command for CI
 CMD ["/bin/bash"]
-

--- a/examples/3-via-apt-get/Makefile
+++ b/examples/3-via-apt-get/Makefile
@@ -24,8 +24,8 @@ run: ## Run the container interactively
 	docker run -it $(IMAGE_NAME):$(IMAGE_TAG)
 
 test: ## Test the Docker image
-	docker run --rm $(IMAGE_NAME):$(IMAGE_TAG) bash -c "curl --version && echo '---' && git --version && echo '---' && jq --version"
-	@echo "Verify that curl, git, and jq versions are displayed above (separated by ---)."
+	docker run --rm $(IMAGE_NAME):$(IMAGE_TAG) bash -c "curl --version && echo '---' && git --version && echo '---' && jq --version && echo '---' && docker --version"
+	@echo "Verify that curl, git, jq, and docker versions are displayed above (separated by ---)."
 
 shell: ## Open an interactive shell in the container
 	docker run -it $(IMAGE_NAME):$(IMAGE_TAG) /bin/bash

--- a/examples/3-via-apt-get/README.md
+++ b/examples/3-via-apt-get/README.md
@@ -1,6 +1,8 @@
 # Installing apt-bundle via APT Repository
 
-A production-ready example demonstrating how to install `apt-bundle` from the official APT repository.
+A production-ready example demonstrating how to install `apt-bundle` from the official APT
+repository, including adding a custom third-party repository (Docker) via `key` and `deb`
+directives.
 
 ## Installation Method
 
@@ -14,7 +16,23 @@ RUN echo "deb [arch=amd64,arm64,armhf,i386 trusted=yes] https://apt-bundle.org/r
 
 ## What's Included
 
-- Utilities: `curl`, `git`
+- Standard utilities: `curl`, `git`, `jq`
+- Docker CLI — installed from Docker's official repository via `key` + `deb` directives
+
+## The key + deb Pattern
+
+The `key` directive downloads a GPG key over HTTPS and the immediately following `deb`
+directive adds the repository with that key as its `Signed-By` field:
+
+```aptfile
+key https://download.docker.com/linux/ubuntu/gpg
+deb "[arch=amd64] https://download.docker.com/linux/ubuntu jammy stable"
+apt docker-ce-cli
+```
+
+This replaces around 10 lines of manual shell commands (curl, gpg --dearmor, chmod, echo,
+tee, etc.) that you would otherwise need in a `Dockerfile`. See `Dockerfile.traditional`
+for the equivalent without apt-bundle.
 
 ## Usage
 
@@ -31,20 +49,24 @@ make test
 
 ## When to Use This Method
 
-- **Production environments** - More reliable and version-controlled
-- **Docker images** - Better layer caching and reproducibility
-- **CI/CD pipelines** - Consistent versions across builds
-- **When you need specific versions** - Can pin to specific apt-bundle versions
-- **Multi-architecture support** - Supports amd64, arm64, armhf, i386
+- **Production environments** — More reliable and version-controlled
+- **Docker images** — Better layer caching and reproducibility
+- **CI/CD pipelines** — Consistent versions across builds
+- **Custom third-party repositories** — `key` + `deb` handles GPG key download and
+  DEB822 repository setup automatically
+- **Multi-architecture support** — Supports amd64, arm64, armhf, i386
 
 ## Benefits Over install.sh
 
-- ✅ Version control - Can pin to specific versions
-- ✅ Better caching - APT caches packages efficiently
-- ✅ Multi-architecture - Supports all architectures
-- ✅ Production-ready - Standard APT package management
-- ✅ Reproducible - Same version every time
+- ✅ Version control — Can pin to specific versions
+- ✅ Better caching — APT caches packages efficiently
+- ✅ Multi-architecture — Supports all architectures
+- ✅ Production-ready — Standard APT package management
+- ✅ Reproducible — Same version every time
+- ✅ Custom repos — `key` + `deb` directives manage GPG keys and sources automatically
 
 ## Note
 
-The `trusted=yes` flag is used because the repository is currently unsigned. For production use, consider setting up GPG signing for the repository.
+The `trusted=yes` flag is used in the apt-bundle repository entry because that repository
+is currently unsigned. The Docker repository itself uses proper GPG signing via the `key`
+directive in the Aptfile.

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,15 +26,16 @@ The examples are organized by **installation method**, **repository type**, and 
 
 **Best for:** Installing packages from PPAs (PHP, Git, Node.js, etc.)
 
-### 3. Via APT Repository (`3-via-apt-get/`)
-**Production-ready approach** - Install from official APT repository with custom repos.
+### 3. Via APT Repository with Custom Repo (`3-via-apt-get/`)
+**Production-ready approach** - Install from official APT repository; demonstrates the
+`key` + `deb` pattern for adding a custom third-party repository (Docker CLI).
 
 - ✅ Version control
 - ✅ Better caching
 - ✅ Multi-architecture support
-- ✅ Custom repositories with GPG keys
+- ✅ Custom repositories with automatic GPG key management
 
-**Best for:** Production Docker images, CI/CD pipelines, custom repositories
+**Best for:** Production Docker images, CI/CD pipelines, any package from a custom repo
 
 ### 4. Complex via APT Repository (`4-complex-via-apt-get/`)
 **Advanced pattern** - Multi-stage builds with many dependencies using APT repository.
@@ -45,6 +46,18 @@ The examples are organized by **installation method**, **repository type**, and 
 - ✅ Clear separation of concerns
 
 **Best for:** Production applications, complex builds, optimized deployments
+
+### 5. With Lock File (`5-with-lockfile/`)
+**Reproducible builds** - Demonstrates the `Aptfile.lock` workflow for pinning every
+package to an exact version.
+
+- ✅ Fully reproducible installs
+- ✅ Version drift detection
+- ✅ Explicit audit trail of installed versions
+- ✅ Works with any installation method
+
+**Best for:** CI/CD pipelines, team environments, production Docker images where you need
+the exact same package versions on every build
 
 ## Quick Start
 
@@ -76,12 +89,35 @@ make build
 make run
 ```
 
+### Example 5: Reproducible builds with lock file
+```bash
+cd 5-with-lockfile
+make build
+make run
+```
+
+## Feature Coverage Matrix
+
+| Feature | 1 | 2 | 3 | 4 | 5 |
+|---|---|---|---|---|---|
+| Basic `apt` packages | ✅ | ✅ | ✅ | ✅ | ✅ |
+| PPA repositories (`ppa`) | | ✅ | | | |
+| Custom repo GPG key (`key`) | | | ✅ | | |
+| Custom `deb` repository | | | ✅ | | |
+| Multi-stage build | | | | ✅ | |
+| Separate Aptfiles per stage | | | | ✅ | |
+| Lock file (`Aptfile.lock`) | | | | | ✅ |
+| Reproducible `--locked` install | | | | | ✅ |
+| Version pinning in Aptfile | | | | | ✅ |
+| `install.sh` setup | ✅ | ✅ | | | |
+| APT repo setup | | | ✅ | ✅ | ✅ |
+
 ## Repository Types Comparison
 
 | Type | Syntax | GPG Key | Use Case |
 |------|--------|---------|----------|
 | **PPA** | `ppa ppa:user/repo` | ✅ Automatic | Ubuntu community packages |
-| **Custom Repo** | `deb "url"` + `key url` | ⚠️ Manual | Official vendor repos (Docker, etc.) |
+| **Custom Repo** | `key url` + `deb "url"` | ✅ Automatic | Official vendor repos (Docker, Node.js, etc.) |
 
 ## Installation Methods Comparison
 


### PR DESCRIPTION
Two related changes to the examples directory:

**Example 3 (`3-via-apt-get/`):**
- Aptfile now demonstrates the `key` + `deb` directive sequence by installing Docker CLI from Docker's official repository. This is the first example to show a real-world custom third-party repository in user Aptfile content (not just the apt-bundle installation preamble).
- `Dockerfile.traditional` updated to show the equivalent ~10 lines of manual shell (curl, gpg --dearmor, chmod, tee, etc.), sharpening the before/after comparison.
- Makefile test target extended to verify `docker --version` alongside the existing curl/git/jq checks.
- README rewritten to explain the `key` + `deb` pattern.

**`examples/README.md`:**
- Updated example 3 description to reflect the Docker CLI addition.
- Added a feature coverage matrix so readers can quickly find which example demonstrates a given capability.
- Added an entry for example 5 (lock file, covered in the companion PR).

Previously all four examples only used `apt` or `ppa` directives in their Aptfiles, so the `key`/`deb` pattern for custom GPG-keyed repositories was not demonstrated anywhere in the examples.

Verified: `make lint vet test` passes in this worktree (all Go tests pass, lint clean).