### PR TITLE
docs: add GitHub Actions page, CI badge, and fix release-triggered deploys

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -10,6 +10,10 @@ on:
       - '!.cursor/**'
   release:
     types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -23,6 +27,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -3,12 +3,17 @@ name: Update APT Repository
 on:
   release:
     types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: write
 
 jobs:
   update-apt-repo:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -16,12 +21,34 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve release tag
+        id: tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "${{ github.event.release.tag_name }}" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+          else
+            TAG=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+              "https://api.github.com/repos/${{ github.repository }}/releases/latest" | \
+              jq -r '.tag_name // empty')
+          fi
+          if [ -z "$TAG" ]; then
+            echo "No release found, skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Install APT tools
+        if: steps.tag.outputs.skip != 'true'
         run: sudo apt-get update && sudo apt-get install -y dpkg-dev apt-utils
 
       - name: Update APT repository
+        if: steps.tag.outputs.skip != 'true'
         env:
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
           VERSION="${TAG#v}"
           cd docs/repo && ./update-repo.sh "$VERSION"
@@ -32,8 +59,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Commit and push
+        if: steps.tag.outputs.skip != 'true'
         env:
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
           git add docs/repo/
           if git diff --staged --quiet; then

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # apt-bundle
 
+[![CI](https://github.com/apt-bundle/apt-bundle/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/apt-bundle/apt-bundle/actions/workflows/ci.yml)
+
 A declarative, Brewfile-like wrapper for `apt`, inspired by `brew bundle` — not a full config management system.
 
 **[📚 Full Documentation](https://apt-bundle.github.io/apt-bundle/)** | [Installation](#installation) | [Usage](#usage)
@@ -310,15 +312,3 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ## License
 
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
-
-## Roadmap
-
-- [x] Core functionality (install, dump, check)
-- [x] Package version handling
-- [x] PPA management
-- [x] Custom repository management
-- [x] GPG key management
-- [x] CI/CD pipeline
-- [x] Release automation
-- [ ] Expand test coverage
-

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,0 +1,118 @@
+---
+layout: default
+title: GitHub Actions
+nav_order: 3.5
+---
+
+# GitHub Actions
+
+The [`apt-bundle/apt-bundle-action`](https://github.com/apt-bundle/apt-bundle-action) GitHub Action provides a first-class integration for using apt-bundle in GitHub workflows. It handles downloading and installing apt-bundle automatically, and includes built-in package caching to speed up repeated runs.
+
+## Quick Start
+
+Add a step to your workflow:
+
+```yaml
+- uses: apt-bundle/apt-bundle-action@v1
+```
+
+This reads `Aptfile` from the repository root, installs packages, and caches the downloaded `.deb` files for future runs.
+
+## Full Example
+
+```yaml
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        uses: apt-bundle/apt-bundle-action@v1
+
+      - name: Run tests
+        run: make test
+```
+
+## Inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `file` | `Aptfile` | Path to the Aptfile |
+| `mode` | `install` | `install`, `install-no-update`, or `check` |
+| `version` | `latest` | apt-bundle version to install |
+| `cache` | `true` | Cache downloaded `.deb` packages |
+| `cache-key-prefix` | `apt-bundle` | Prefix for the cache key |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `cache-hit` | `true` if packages were restored from cache |
+
+## Caching
+
+Caching is enabled by default. The cache key is derived from a SHA256 hash of `Aptfile.lock` (if present) or `Aptfile`. The cache is automatically invalidated whenever dependencies change.
+
+To disable caching:
+
+```yaml
+- uses: apt-bundle/apt-bundle-action@v1
+  with:
+    cache: false
+```
+
+## Reproducible Builds with Aptfile.lock
+
+If your repository includes an `Aptfile.lock`, the action uses it as the cache key and installs the exact package versions recorded in the lockfile, ensuring reproducible builds across runs and machines.
+
+```yaml
+- uses: apt-bundle/apt-bundle-action@v1
+# Automatically uses Aptfile.lock if present
+```
+
+See the [Aptfile Format](aptfile-format.html) page for how to generate a lockfile.
+
+## Validating Dependencies in Pull Requests
+
+Use `mode: check` to verify that the Aptfile is consistent with what the build environment provides, without installing anything:
+
+```yaml
+- name: Validate dependencies
+  uses: apt-bundle/apt-bundle-action@v1
+  with:
+    mode: check
+```
+
+This is useful as a lightweight lint step on pull requests.
+
+## Pinning a Version
+
+To use a specific apt-bundle release rather than `latest`:
+
+```yaml
+- uses: apt-bundle/apt-bundle-action@v1
+  with:
+    version: 1.2.3
+```
+
+## Custom Aptfile Location
+
+```yaml
+- uses: apt-bundle/apt-bundle-action@v1
+  with:
+    file: .github/Aptfile
+```
+
+## Requirements
+
+- Ubuntu runners only (`ubuntu-*`)
+- Standard GitHub-hosted runners have the necessary `sudo` access
+
+---
+
+See the [action repository](https://github.com/apt-bundle/apt-bundle-action) for the full source and changelog.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ A declarative package manager for apt, inspired by Homebrew's `brew bundle`.
 - **Repository & Key Management**: Add PPAs, custom repositories, and GPG keys
 - **Version Pinning**: Install specific package versions
 - **Simple CLI**: Easy-to-use command-line interface
+- **GitHub Actions Integration**: Native action with built-in caching for CI/CD
 
 ## Quick Start
 
@@ -54,12 +55,13 @@ Replace long, unmaintainable `RUN apt-get install -y ...` lines with a simple `A
 Use `apt-bundle dump > Aptfile` on your primary workstation and then `sudo apt-bundle` on a new laptop to sync your tools.
 
 ### CI/CD
-Use `apt-bundle check` to validate that the build environment has the necessary dependencies.
+Use the [GitHub Action](github-actions.html) for seamless integration with GitHub workflows, including built-in package caching and reproducible builds via lockfiles.
 
 ## Documentation
 
 - [Installation](installation.html) - How to install apt-bundle
 - [Usage](usage.html) - Command reference and examples
+- [GitHub Actions](github-actions.html) - Using apt-bundle in GitHub workflows
 - [Aptfile Format](aptfile-format.html) - Complete syntax reference
 - [Contributing](contributing.html) - Contributing and development setup
 - [API Reference](api-reference.html) - Go package documentation

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -147,13 +147,26 @@ sudo apt-bundle
 
 Use `apt-bundle` in your Dockerfiles to manage system dependencies declaratively. See the [examples directory](../../examples/) for complete working examples including multi-stage builds, Python runtimes, CI/CD setups, and more.
 
-### CI/CD Validation
+### CI/CD with GitHub Actions
+
+The [`apt-bundle/apt-bundle-action`](https://github.com/apt-bundle/apt-bundle-action) GitHub Action provides a streamlined integration with built-in package caching:
 
 ```yaml
 # .github/workflows/test.yml
-- name: Check dependencies
-  run: apt-bundle check
+- name: Install system dependencies
+  uses: apt-bundle/apt-bundle-action@v1
 ```
+
+To validate dependencies without installing (e.g. in a lint step):
+
+```yaml
+- name: Check dependencies
+  uses: apt-bundle/apt-bundle-action@v1
+  with:
+    mode: check
+```
+
+See the [GitHub Actions](github-actions.html) page for the full reference.
 
 ### System Sync
 


### PR DESCRIPTION
## Summary

- **New page** `docs/github-actions.md`: full reference for `apt-bundle/apt-bundle-action` — inputs/outputs, caching behaviour, lockfile-based reproducible builds, `check` mode for PR validation, version pinning, custom Aptfile paths
- **Site cross-links**: `docs/index.md` (features list, CI/CD use case, documentation nav) and `docs/usage.md` (CI/CD section) both reference the new page
- **CI badge** added to `README.md` (pinned to `branch=main`)
- **Bug fix** — `deploy-pages.yml` and `update-apt-repo.yml`: the existing `release: published` trigger is dead code because GitHub blocks workflows from triggering other workflows when using `GITHUB_TOKEN`. Both workflows now also trigger via `workflow_run` on the Release workflow completing, which is not subject to that restriction. A `conclusion == 'success'` guard prevents spurious runs onease failures. `update-apt-repo` gains a `Resolve release tag` step that falls back to the releases API when the event tag isn't available.

## Test plan

- [ ] Review new `docs/github-actions.md` page content and links
- [ ] Confirm CI badge renders correctly on GitHub README
- [ ] After merge, verify that the next release triggers `deploy-pages` and `update-apt-repo` automatically (check Actions tab)
- [ ] Verify deployed site shows the correct version number at https://apt-bundle.org/repo/README.html#current-version