### PR TITLE
feat: support signed-by= in deb options + GitHub CLI example

### DIFF
--- a/docs/aptfile-format.md
+++ b/docs/aptfile-format.md
@@ -87,6 +87,25 @@ deb "[arch=amd64] https://download.docker.com/linux/ubuntu focal stable"
 - This directive only adds the repository line; it does not add the GPG key
 - You must use the `key` directive separately to add the required GPG key
 - Repository lines can include options like `[arch=amd64]` or `[trusted=yes]`
+- `signed-by=<path>` is supported in the options block and takes precedence over the implicit key linking from a preceding `key` directive; this is useful for copy-paste compatibility with official installation docs
+
+**Recommended pattern** — use `key` + `deb` without `signed-by=`; apt-bundle automatically links them:
+
+```aptfile
+key https://cli.github.com/packages/githubcli-archive-keyring.gpg
+deb "[arch=amd64] https://cli.github.com/packages stable main"
+apt gh
+```
+
+**Advanced / copy-paste from official docs** — explicit `signed-by=` is also accepted:
+
+```aptfile
+key https://cli.github.com/packages/githubcli-archive-keyring.gpg
+deb "[arch=amd64 signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main"
+apt gh
+```
+
+When using the explicit form, the path in `signed-by=` must already exist on the system (e.g. written by the `key` directive to `/etc/apt/keyrings/`).
 
 ### `key` - Add GPG Key
 
@@ -195,6 +214,17 @@ apt docker-ce-cli
 apt containerd.io
 apt docker-compose-plugin
 ```
+
+### GitHub CLI
+
+```aptfile
+key https://cli.github.com/packages/githubcli-archive-keyring.gpg
+deb "[arch=amd64] https://cli.github.com/packages stable main"
+apt gh
+```
+
+The `signed-by=` form from the official GitHub CLI docs is also accepted if you prefer
+to copy-paste it directly.
 
 ### Language-Specific Setup
 

--- a/examples/6-github-cli/Aptfile
+++ b/examples/6-github-cli/Aptfile
@@ -1,0 +1,6 @@
+# GitHub CLI - https://cli.github.com
+# 'key' downloads and saves the GPG key; the following 'deb' is automatically
+# signed by it (Signed-By is set in the generated DEB822 sources file).
+key https://cli.github.com/packages/githubcli-archive-keyring.gpg
+deb "[arch=amd64] https://cli.github.com/packages stable main"
+apt gh

--- a/examples/6-github-cli/Dockerfile
+++ b/examples/6-github-cli/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:22.04
+
+ARG APT_BUNDLE_REPO_ENTRY="deb [arch=amd64,arm64,armhf,i386 trusted=yes] https://apt-bundle.org/repo/ stable main"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install prerequisites and apt-bundle from APT repository
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates
+
+RUN echo "$APT_BUNDLE_REPO_ENTRY" | tee /etc/apt/sources.list.d/apt-bundle.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends apt-bundle && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI via apt-bundle
+COPY Aptfile /app/Aptfile
+WORKDIR /app
+RUN apt-bundle install --file /app/Aptfile
+
+# Clean up apt cache to reduce image size
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+CMD ["/bin/bash"]

--- a/examples/6-github-cli/Dockerfile.traditional
+++ b/examples/6-github-cli/Dockerfile.traditional
@@ -1,0 +1,25 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install GitHub CLI manually (no apt-bundle).
+# apt-bundle replaces the block below with three lines: key + deb + apt.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
+        gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    chmod a+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | \
+        tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gh && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+CMD ["/bin/bash"]

--- a/examples/6-github-cli/Makefile
+++ b/examples/6-github-cli/Makefile
@@ -1,0 +1,37 @@
+IMAGE_NAME ?= github-cli-example
+IMAGE_TAG ?= latest
+DOCKERFILE ?= Dockerfile
+
+.DEFAULT_GOAL := help
+
+.PHONY: help build run test shell ci clean
+
+help: ## Show this help message
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Variables:"
+	@echo "  IMAGE_NAME  Docker image name (default: $(IMAGE_NAME))"
+	@echo "  IMAGE_TAG   Docker image tag (default: $(IMAGE_TAG))"
+	@echo "  DOCKERFILE  Dockerfile to use (default: $(DOCKERFILE))"
+	@echo ""
+build: ## Build the Docker image
+	docker build -f $(DOCKERFILE) -t $(IMAGE_NAME):$(IMAGE_TAG) .
+
+run: ## Run the container interactively
+	docker run -it $(IMAGE_NAME):$(IMAGE_TAG)
+
+test: ## Test the Docker image
+	docker run --rm $(IMAGE_NAME):$(IMAGE_TAG) gh --version
+	@echo "Verify that the gh version is displayed above."
+
+shell: ## Open an interactive shell in the container
+	docker run -it $(IMAGE_NAME):$(IMAGE_TAG) /bin/bash
+
+ci: ## Run CI mode (mounts current directory as /workspace)
+	docker run -v $$(pwd):/workspace $(IMAGE_NAME):$(IMAGE_TAG)
+
+clean: ## Remove the Docker image
+	docker rmi $(IMAGE_NAME):$(IMAGE_TAG) || true

--- a/examples/6-github-cli/README.md
+++ b/examples/6-github-cli/README.md
@@ -1,0 +1,56 @@
+# Example 6: GitHub CLI
+
+This example demonstrates installing **GitHub CLI** (`gh`) from its official APT repository
+using apt-bundle's `key` + `deb` pattern — the most common real-world use case for custom
+third-party repositories with GPG key pinning.
+
+## The Aptfile
+
+```aptfile
+# GitHub CLI - https://cli.github.com
+# 'key' downloads and saves the GPG key; the following 'deb' is automatically
+# signed by it (Signed-By is set in the generated DEB822 sources file).
+key https://cli.github.com/packages/githubcli-archive-keyring.gpg
+deb "[arch=amd64] https://cli.github.com/packages stable main"
+apt gh
+```
+
+apt-bundle automatically links the downloaded GPG key to the repository: no need to
+spell out `signed-by=` in the `deb` line.
+
+## Explicit `signed-by=` (copy-paste from official docs)
+
+Official GitHub CLI installation instructions include `signed-by=` in the deb options.
+apt-bundle now accepts that form too, so you can copy-paste it directly:
+
+```aptfile
+key https://cli.github.com/packages/githubcli-archive-keyring.gpg
+deb "[arch=amd64 signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main"
+apt gh
+```
+
+When `signed-by=` is present in the `deb` options it takes precedence over the
+implicit key path — the path must already exist on the system (written by the
+preceding `key` directive).
+
+## Usage
+
+```bash
+# Build with apt-bundle (Dockerfile)
+make build
+
+# Or build the traditional equivalent (no apt-bundle)
+make build DOCKERFILE=Dockerfile.traditional
+
+# Test: runs gh --version inside the container
+make test
+
+# Interactive shell
+make shell
+```
+
+## What `Dockerfile.traditional` shows
+
+`Dockerfile.traditional` is the equivalent ~15-line shell block that the three
+apt-bundle lines replace: download key with curl, dearmor, write sources file,
+`apt-get update`, `apt-get install gh`. It is provided for comparison only.

--- a/examples/README.md
+++ b/examples/README.md
@@ -59,6 +59,19 @@ package to an exact version.
 **Best for:** CI/CD pipelines, team environments, production Docker images where you need
 the exact same package versions on every build
 
+### 6. GitHub CLI (`6-github-cli/`)
+**Real-world third-party repo** - Installs GitHub CLI (`gh`) from its official APT
+repository; demonstrates the `key` + `deb` pattern and the new `signed-by=` option
+support for copy-paste compatibility with official installation docs.
+
+- ✅ Custom repo GPG key (`key` directive)
+- ✅ Custom `deb` repository
+- ✅ `signed-by=` in deb options (copy-paste from official docs)
+- ✅ Traditional equivalent for comparison
+
+**Best for:** Any package from a vendor-hosted APT repository that ships official
+installation instructions with `signed-by=` in the deb line
+
 ## Quick Start
 
 ### Example 1: Simple install.sh approach
@@ -96,21 +109,29 @@ make build
 make run
 ```
 
+### Example 6: GitHub CLI
+```bash
+cd 6-github-cli
+make build
+make test
+```
+
 ## Feature Coverage Matrix
 
-| Feature | 1 | 2 | 3 | 4 | 5 |
-|---|---|---|---|---|---|
-| Basic `apt` packages | ✅ | ✅ | ✅ | ✅ | ✅ |
-| PPA repositories (`ppa`) | | ✅ | | | |
-| Custom repo GPG key (`key`) | | | ✅ | | |
-| Custom `deb` repository | | | ✅ | | |
-| Multi-stage build | | | | ✅ | |
-| Separate Aptfiles per stage | | | | ✅ | |
-| Lock file (`Aptfile.lock`) | | | | | ✅ |
-| Reproducible `--locked` install | | | | | ✅ |
-| Version pinning in Aptfile | | | | | ✅ |
-| `install.sh` setup | ✅ | ✅ | | | |
-| APT repo setup | | | ✅ | ✅ | ✅ |
+| Feature | 1 | 2 | 3 | 4 | 5 | 6 |
+|---|---|---|---|---|---|---|
+| Basic `apt` packages | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| PPA repositories (`ppa`) | | ✅ | | | | |
+| Custom repo GPG key (`key`) | | | ✅ | | | ✅ |
+| Custom `deb` repository | | | ✅ | | | ✅ |
+| `signed-by=` in deb options | | | | | | ✅ |
+| Multi-stage build | | | | ✅ | | |
+| Separate Aptfiles per stage | | | | ✅ | | |
+| Lock file (`Aptfile.lock`) | | | | | ✅ | |
+| Reproducible `--locked` install | | | | | ✅ | |
+| Version pinning in Aptfile | | | | | ✅ | |
+| `install.sh` setup | ✅ | ✅ | | | | |
+| APT repo setup | | | ✅ | ✅ | ✅ | ✅ |
 
 ## Repository Types Comparison
 

--- a/internal/apt/repositories.go
+++ b/internal/apt/repositories.go
@@ -21,7 +21,10 @@ const (
 var optionsRegex = regexp.MustCompile(`^\[([^\]]+)\]\s*`)
 
 // archRegex extracts the arch= value from bracketed options
-var archRegex = regexp.MustCompile(`arch=([^\s]+)`)
+var archRegex = regexp.MustCompile(`arch=([^\s\]]+)`)
+
+// signedByRegex extracts the signed-by= value from bracketed options
+var signedByRegex = regexp.MustCompile(`signed-by=([^\s\]]+)`)
 
 // isUbuntu checks if the current system is Ubuntu by reading /etc/os-release.
 // Parses key=value pairs properly to avoid false positives from fields like
@@ -111,8 +114,8 @@ func (m *AptManager) AddDebRepository(repoLine string, keyPath string) (string, 
 		return "", fmt.Errorf("failed to parse deb line: %w", err)
 	}
 
-	// Set the Signed-By field if a key path was provided
-	if keyPath != "" {
+	// Explicit signed-by= in the deb line takes precedence over the implicit pendingKeyPath.
+	if keyPath != "" && repo.SignedBy == "" {
 		repo.SignedBy = keyPath
 	}
 
@@ -168,6 +171,10 @@ func parseDebLine(line string) (*DebRepository, error) {
 		// Parse arch option
 		if archMatches := archRegex.FindStringSubmatch(options); len(archMatches) > 1 {
 			repo.Architectures = archMatches[1]
+		}
+		// Parse signed-by option
+		if sbMatches := signedByRegex.FindStringSubmatch(options); len(sbMatches) > 1 {
+			repo.SignedBy = sbMatches[1]
 		}
 	}
 

--- a/internal/apt/repositories_test.go
+++ b/internal/apt/repositories_test.go
@@ -273,6 +273,48 @@ func TestParseDebLine(t *testing.T) {
 			t.Errorf("Expected URI 'https://example.com/ubuntu', got '%s'", repo.URIs)
 		}
 	})
+
+	t.Run("deb line with signed-by option", func(t *testing.T) {
+		repo, err := parseDebLine("[signed-by=/etc/apt/keyrings/test.gpg] https://example.com/repo stable main")
+		if err != nil {
+			t.Fatalf("parseDebLine failed: %v", err)
+		}
+		if repo.SignedBy != "/etc/apt/keyrings/test.gpg" {
+			t.Errorf("Expected SignedBy '/etc/apt/keyrings/test.gpg', got '%s'", repo.SignedBy)
+		}
+		if repo.Architectures != "" {
+			t.Errorf("Expected empty Architectures, got '%s'", repo.Architectures)
+		}
+	})
+
+	t.Run("deb line with arch and signed-by options", func(t *testing.T) {
+		repo, err := parseDebLine("[arch=amd64 signed-by=/etc/apt/keyrings/githubcli.gpg] https://cli.github.com/packages stable main")
+		if err != nil {
+			t.Fatalf("parseDebLine failed: %v", err)
+		}
+		if repo.Architectures != "amd64" {
+			t.Errorf("Expected Architectures 'amd64', got '%s'", repo.Architectures)
+		}
+		if repo.SignedBy != "/etc/apt/keyrings/githubcli.gpg" {
+			t.Errorf("Expected SignedBy '/etc/apt/keyrings/githubcli.gpg', got '%s'", repo.SignedBy)
+		}
+		if repo.URIs != "https://cli.github.com/packages" {
+			t.Errorf("Expected URI 'https://cli.github.com/packages', got '%s'", repo.URIs)
+		}
+	})
+
+	t.Run("deb line with signed-by but no arch", func(t *testing.T) {
+		repo, err := parseDebLine("[signed-by=/etc/apt/keyrings/myrepo.gpg] https://example.com/repo focal main")
+		if err != nil {
+			t.Fatalf("parseDebLine failed: %v", err)
+		}
+		if repo.SignedBy != "/etc/apt/keyrings/myrepo.gpg" {
+			t.Errorf("Expected SignedBy '/etc/apt/keyrings/myrepo.gpg', got '%s'", repo.SignedBy)
+		}
+		if repo.Architectures != "" {
+			t.Errorf("Expected empty Architectures, got '%s'", repo.Architectures)
+		}
+	})
 }
 
 func TestDebRepositoryToDEB822(t *testing.T) {
@@ -373,6 +415,37 @@ func TestAddDebRepository(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "https") {
 			t.Errorf("Expected https rejection message, got: %v", err)
+		}
+	})
+
+	t.Run("explicit signed-by overrides keyPath", func(t *testing.T) {
+		repoLine := "[arch=amd64 signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main"
+		keyPath := filepath.Join(tmpDir, "implicit.gpg")
+
+		if err := os.WriteFile(keyPath, []byte("fake key"), 0644); err != nil {
+			t.Fatalf("Failed to create fake key file: %v", err)
+		}
+
+		m := &AptManager{
+			SourcesDir:    tmpDir,
+			SourcesPrefix: "apt-bundle-explicit-",
+		}
+
+		sourcePath, err := m.AddDebRepository(repoLine, keyPath)
+		if err != nil {
+			t.Fatalf("AddDebRepository failed: %v", err)
+		}
+
+		content, err := os.ReadFile(sourcePath)
+		if err != nil {
+			t.Fatalf("Failed to read sources file: %v", err)
+		}
+
+		if !strings.Contains(string(content), "Signed-By: /etc/apt/keyrings/githubcli-archive-keyring.gpg") {
+			t.Errorf("Expected explicit signed-by path in sources file, got:\n%s", content)
+		}
+		if strings.Contains(string(content), keyPath) {
+			t.Errorf("keyPath should NOT appear in sources file when deb line has signed-by=, got:\n%s", content)
 		}
 	})
 }


### PR DESCRIPTION
Parse signed-by= from bracketed deb line options so users can copy-paste official vendor installation instructions (e.g. GitHub CLI) directly into their Aptfile. When signed-by= is present in the deb line it takes precedence over the implicit key path set by a preceding key directive.

- Add signedByRegex; update parseDebLine to extract signed-by=
- Guard AddDebRepository so explicit signed-by= is never overwritten
- New TestParseDebLine subtests for signed-by= variants
- New TestAddDebRepository subtest verifying precedence
- docs/aptfile-format.md: document signed-by= option and GitHub CLI pattern
- examples/6-github-cli/: full example (Aptfile, Dockerfile, Dockerfile.traditional, Makefile, README)
- examples/README.md: add example 6 to overview and feature matrix