### PR TITLE
fix: include semver + commit hash in --version output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,9 +121,14 @@ jobs:
           NFPM_ARCH: ${{ matrix.debarch }}
         run: |
           # Build binary for this architecture
+          COMMIT=$(git rev-parse --short HEAD)
           mkdir -p build dist
           CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} \
-            go build -ldflags="-s -w" -o build/apt-bundle ./cmd/apt-bundle
+            go build \
+              -ldflags="-s -w \
+                -X github.com/apt-bundle/apt-bundle/internal/commands.version=${VERSION} \
+                -X github.com/apt-bundle/apt-bundle/internal/commands.commit=${COMMIT}" \
+              -o build/apt-bundle ./cmd/apt-bundle
           
           # Substitute template variables in nfpm config
           # nfpm v2 doesn't automatically process {{ .Version }} and {{ .Arch }} templates

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ BINARY_NAME=apt-bundle
 BUILD_DIR=build
 GO=go
 VERSION := $(shell cat VERSION | tr -d '[:space:]').0
-GOFLAGS=-ldflags="-s -w -X github.com/apt-bundle/apt-bundle/internal/commands.version=$(VERSION)"
+COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+GOFLAGS=-ldflags="-s -w \
+  -X github.com/apt-bundle/apt-bundle/internal/commands.version=$(VERSION) \
+  -X github.com/apt-bundle/apt-bundle/internal/commands.commit=$(COMMIT)"
 INSTALL_DIR ?= /usr/local/bin
 USE_SUDO ?= sudo
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -65,7 +65,7 @@ This command outputs a list of manually installed packages. Future versions may 
 
 - `--file, -f`: Specify the path to the Aptfile (default: `./Aptfile`)
 - `--help, -h`: Show help information
-- `--version`: Show version information
+- `--version`: Show version and build information (e.g. `0.2.54 (abc1234)`)
 
 ### Install Command Flags
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -12,6 +12,7 @@ var (
 	aptfilePath string
 	noUpdate    bool
 	version     = "dev"
+	commit      = "unknown"
 )
 
 // mgr is the AptManager used by all commands.
@@ -26,7 +27,6 @@ var rootCmd = &cobra.Command{
 	Long: `apt-bundle provides a simple, declarative, and shareable way to manage
 apt packages and repositories on Debian-based systems, inspired by Homebrew's
 brew bundle.`,
-	Version: version,
 }
 
 func Execute() error {
@@ -34,6 +34,7 @@ func Execute() error {
 }
 
 func init() {
+	rootCmd.Version = version + " (" + commit + ")"
 	rootCmd.PersistentFlags().StringVarP(&aptfilePath, "file", "f", "Aptfile", "Path to Aptfile")
 	rootCmd.PersistentFlags().BoolVar(&noUpdate, "no-update", false, "Skip updating package lists before installing")
 }

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -38,6 +39,13 @@ func TestRootCmd(t *testing.T) {
 
 		if rootCmd.Version == "" {
 			t.Error("rootCmd.Version should not be empty")
+		}
+	})
+
+	t.Run("version flag format", func(t *testing.T) {
+		v := rootCmd.Version
+		if !strings.Contains(v, " (") || !strings.HasSuffix(v, ")") {
+			t.Errorf("rootCmd.Version %q does not match expected format '<version> (<commit>)'", v)
 		}
 	})
 
@@ -89,6 +97,20 @@ func TestCheckRoot(t *testing.T) {
 			if err == nil {
 				t.Error("checkRoot() should return error when not running as root")
 			}
+		}
+	})
+}
+
+func TestVersionVariables(t *testing.T) {
+	t.Run("version defaults to dev", func(t *testing.T) {
+		if version != "dev" {
+			t.Errorf("version = %q, want %q", version, "dev")
+		}
+	})
+
+	t.Run("commit defaults to unknown", func(t *testing.T) {
+		if commit != "unknown" {
+			t.Errorf("commit = %q, want %q", commit, "unknown")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- `--version` previously printed `apt-bundle version dev` for all release builds because the CI build step used `-ldflags="-s -w"` without the `-X` flags to inject the version string
- Adds a `commit` var (default `"unknown"`) alongside the existing `version` var, and formats the output as `<version> (<commit>)` (e.g. `0.2.54 (abc1234)`)

## Changes

- **`internal/commands/root.go`**: Add `commit = "unknown"` var; move `Version` assignment to `init()` as `version + " (" + commit + ")"`
- **`Makefile`**: Add `COMMIT` from `git rev-parse --short HEAD`; extend `GOFLAGS` to inject both `-X` ldflags
- **`.github/workflows/release.yml`**: Fix build step to capture `COMMIT` and pass both `-X` ldflags so release binaries report the correct version and hash
- **`internal/commands/root_test.go`**: Add `TestVersionVariables` (checks defaults) and `"version flag format"` sub-test (checks `<ver> (<commit>)` pattern)
- **`docs/usage.md`**: Update `--version` description to show the new format

## Test plan

- [x] `make build && ./build/apt-bundle --version` → `apt-bundle version 0.2.0 (24e53a7)`
- [x] `go run ./cmd/apt-bundle --version` (no ldflags) → `apt-bundle version dev (unknown)`
- [x] `go test -v -race -p 1 ./internal/commands/... -run "TestVersion|TestRootCmd"` → all pass
- [x] `go test -v -race -p 1 ./...` → full suite passes