### PR TITLE
feat: named key association + dump round-trip for signed-by repos (closes #67)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,9 +121,14 @@ jobs:
           NFPM_ARCH: ${{ matrix.debarch }}
         run: |
           # Build binary for this architecture
+          COMMIT=$(git rev-parse --short HEAD)
           mkdir -p build dist
           CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} \
-            go build -ldflags="-s -w" -o build/apt-bundle ./cmd/apt-bundle
+            go build \
+              -ldflags="-s -w \
+                -X github.com/apt-bundle/apt-bundle/internal/commands.version=${VERSION} \
+                -X github.com/apt-bundle/apt-bundle/internal/commands.commit=${COMMIT}" \
+              -o build/apt-bundle ./cmd/apt-bundle
           
           # Substitute template variables in nfpm config
           # nfpm v2 doesn't automatically process {{ .Version }} and {{ .Arch }} templates

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ BINARY_NAME=apt-bundle
 BUILD_DIR=build
 GO=go
 VERSION := $(shell cat VERSION | tr -d '[:space:]').0
-GOFLAGS=-ldflags="-s -w -X github.com/apt-bundle/apt-bundle/internal/commands.version=$(VERSION)"
+COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+GOFLAGS=-ldflags="-s -w \
+  -X github.com/apt-bundle/apt-bundle/internal/commands.version=$(VERSION) \
+  -X github.com/apt-bundle/apt-bundle/internal/commands.commit=$(COMMIT)"
 INSTALL_DIR ?= /usr/local/bin
 USE_SUDO ?= sudo
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -65,7 +65,7 @@ This command outputs a list of manually installed packages. Future versions may 
 
 - `--file, -f`: Specify the path to the Aptfile (default: `./Aptfile`)
 - `--help, -h`: Show help information
-- `--version`: Show version information
+- `--version`: Show version and build information (e.g. `0.2.54 (abc1234)`)
 
 ### Install Command Flags
 

--- a/internal/apt/keys.go
+++ b/internal/apt/keys.go
@@ -111,6 +111,13 @@ func (m *AptManager) AddGPGKey(keyURL string) (string, error) {
 		return "", fmt.Errorf("failed to write key file: %w", err)
 	}
 
+	// Write companion URL file so the dump command can reconstruct key directives.
+	urlFilePath := keyPath + ".url"
+	if err := os.WriteFile(urlFilePath, []byte(keyURL), 0644); err != nil {
+		// Non-fatal: dump round-trip will not include this key, but install still works.
+		fmt.Fprintf(os.Stderr, "warning: failed to write key URL file %s: %v\n", urlFilePath, err)
+	}
+
 	fmt.Printf("✓ GPG key saved to: %s\n", keyPath)
 	return keyPath, nil
 }
@@ -135,13 +142,15 @@ func (m *AptManager) dearmorKey(data []byte) ([]byte, error) {
 	}
 	tmpFile.Close()
 
-	// Create a temp file for the dearmored output
+	// Create a temp file to reserve the output path, then remove it so gpg can
+	// write to that path without refusing to overwrite an existing file.
 	outFile, err := os.CreateTemp("", "apt-bundle-key-*.gpg")
 	if err != nil {
 		return nil, fmt.Errorf("create temp output file for dearmor: %w", err)
 	}
 	outPath := outFile.Name()
 	outFile.Close()
+	os.Remove(outPath) // gpg refuses to overwrite existing files; remove before writing
 	defer os.Remove(outPath)
 
 	// Run gpg --dearmor
@@ -153,10 +162,12 @@ func (m *AptManager) dearmorKey(data []byte) ([]byte, error) {
 	return os.ReadFile(outPath)
 }
 
-// RemoveGPGKey removes a GPG key file
+// RemoveGPGKey removes a GPG key file and its companion URL file (if present)
 func (m *AptManager) RemoveGPGKey(keyPath string) error {
 	if err := os.Remove(keyPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to remove key: %w", err)
 	}
+	// Best-effort removal of companion URL file; ignore errors.
+	_ = os.Remove(keyPath + ".url")
 	return nil
 }

--- a/internal/apt/keys_test.go
+++ b/internal/apt/keys_test.go
@@ -29,7 +29,8 @@ func TestAddGPGKey(t *testing.T) {
 			},
 		}
 
-		keyPath, err := m.AddGPGKey("https://example.com/key.gpg")
+		const keyURL = "https://example.com/key.gpg"
+		keyPath, err := m.AddGPGKey(keyURL)
 		if err != nil {
 			t.Fatalf("AddGPGKey failed: %v", err)
 		}
@@ -38,6 +39,15 @@ func TestAddGPGKey(t *testing.T) {
 		}
 		if _, err := os.Stat(keyPath); err != nil {
 			t.Errorf("Key file should exist at %s: %v", keyPath, err)
+		}
+
+		// Verify companion URL file was written
+		urlFilePath := keyPath + ".url"
+		urlData, err := os.ReadFile(urlFilePath)
+		if err != nil {
+			t.Errorf("Companion URL file should exist at %s: %v", urlFilePath, err)
+		} else if string(urlData) != keyURL {
+			t.Errorf("Companion URL file content = %q, want %q", string(urlData), keyURL)
 		}
 	})
 
@@ -135,6 +145,29 @@ func TestRemoveGPGKey(t *testing.T) {
 
 		if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
 			t.Error("Key file should have been removed")
+		}
+	})
+
+	t.Run("remove existing key and companion URL file", func(t *testing.T) {
+		keyPath := filepath.Join(tmpDir, "test-with-url.gpg")
+		urlFilePath := keyPath + ".url"
+		if err := os.WriteFile(keyPath, []byte("key data"), 0644); err != nil {
+			t.Fatalf("Failed to create key file: %v", err)
+		}
+		if err := os.WriteFile(urlFilePath, []byte("https://example.com/key.gpg"), 0644); err != nil {
+			t.Fatalf("Failed to create URL file: %v", err)
+		}
+
+		err := m.RemoveGPGKey(keyPath)
+		if err != nil {
+			t.Errorf("RemoveGPGKey failed: %v", err)
+		}
+
+		if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+			t.Error("Key file should have been removed")
+		}
+		if _, err := os.Stat(urlFilePath); !os.IsNotExist(err) {
+			t.Error("Companion URL file should have been removed")
 		}
 	})
 

--- a/internal/apt/repositories.go
+++ b/internal/apt/repositories.go
@@ -10,9 +10,12 @@ import (
 	"strings"
 )
 
+// SourcesDir is where apt sources files are stored.
+// It is exported as a package-level variable solely to allow test
+// overrides; production code should not modify it.
+var SourcesDir = "/etc/apt/sources.list.d"
+
 const (
-	// SourcesDir is where apt sources files are stored
-	SourcesDir = "/etc/apt/sources.list.d"
 	// SourcesPrefix is the prefix for apt-bundle managed sources files
 	SourcesPrefix = "apt-bundle-"
 )

--- a/internal/apt/sources.go
+++ b/internal/apt/sources.go
@@ -21,6 +21,7 @@ var SourcesListPath = "/etc/apt/sources.list"
 type SourceEntry struct {
 	Type        string // "ppa" or "deb"
 	AptfileLine string
+	KeyURL      string // source URL of the associated GPG key, if known (from companion .url file)
 }
 
 // defaultURIs are distro default repository hosts; entries from these are skipped when dumping
@@ -211,7 +212,7 @@ func readDEB822File(path string) ([]SourceEntry, error) {
 // Note: composite "Types: deb deb-src" is not yet handled; such stanzas
 // are treated as "deb" only. TODO: handle "deb deb-src" correctly.
 func parseDEB822Stanza(lines []string) (SourceEntry, bool) {
-	var types, uris, suites, components, architectures string
+	var types, uris, suites, components, architectures, signedBy string
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
@@ -231,6 +232,8 @@ func parseDEB822Stanza(lines []string) (SourceEntry, bool) {
 				components = val
 			case "Architectures":
 				architectures = val
+			case "Signed-By":
+				signedBy = val
 			}
 		}
 	}
@@ -253,5 +256,16 @@ func parseDEB822Stanza(lines []string) (SourceEntry, bool) {
 	if components != "" {
 		line += " " + components
 	}
-	return SourceEntry{Type: "deb", AptfileLine: line}, true
+	entry := SourceEntry{Type: "deb", AptfileLine: line}
+
+	// If the stanza has a Signed-By key path, try to read the companion URL file
+	// written by apt-bundle when the key was downloaded. If found, populate KeyURL
+	// so the dump command can emit a "key <url>" directive for round-trip fidelity.
+	if signedBy != "" {
+		if urlData, err := os.ReadFile(signedBy + ".url"); err == nil {
+			entry.KeyURL = strings.TrimSpace(string(urlData))
+		}
+	}
+
+	return entry, true
 }

--- a/internal/apt/sources_test.go
+++ b/internal/apt/sources_test.go
@@ -253,6 +253,79 @@ Suites: jammy
 	}
 }
 
+func TestParseDEB822StanzaSignedBy(t *testing.T) {
+	t.Run("Signed-By with companion URL file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		keyPath := filepath.Join(tmpDir, "apt-bundle-abc123.gpg")
+		urlFilePath := keyPath + ".url"
+		const keyURL = "https://repo.charm.sh/apt/gpg.key"
+
+		if err := os.WriteFile(keyPath, []byte("fake key"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(urlFilePath, []byte(keyURL), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		content := "Types: deb\nURIs: https://repo.charm.sh/apt\nSuites: *\nComponents: *\nSigned-By: " + keyPath + "\n"
+		path := filepath.Join(tmpDir, "charm.sources")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		entries, err := readDEB822File(path)
+		if err != nil {
+			t.Fatalf("readDEB822File: %v", err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(entries))
+		}
+		if entries[0].KeyURL != keyURL {
+			t.Errorf("KeyURL = %q, want %q", entries[0].KeyURL, keyURL)
+		}
+	})
+
+	t.Run("Signed-By without companion URL file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		content := "Types: deb\nURIs: https://example.com/apt\nSuites: focal\nSigned-By: /etc/apt/keyrings/no-url-file.gpg\n"
+		path := filepath.Join(tmpDir, "test.sources")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		entries, err := readDEB822File(path)
+		if err != nil {
+			t.Fatalf("readDEB822File: %v", err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(entries))
+		}
+		if entries[0].KeyURL != "" {
+			t.Errorf("KeyURL should be empty when URL file absent, got %q", entries[0].KeyURL)
+		}
+	})
+
+	t.Run("no Signed-By field", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		content := "Types: deb\nURIs: https://example.com/apt\nSuites: focal\nComponents: main\n"
+		path := filepath.Join(tmpDir, "test.sources")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		entries, err := readDEB822File(path)
+		if err != nil {
+			t.Fatalf("readDEB822File: %v", err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(entries))
+		}
+		if entries[0].KeyURL != "" {
+			t.Errorf("KeyURL should be empty when no Signed-By, got %q", entries[0].KeyURL)
+		}
+	})
+}
+
 func TestReadDEB822FileMultiStanza(t *testing.T) {
 	content := `Types: deb
 URIs: https://repo-a.example.com/apt

--- a/internal/aptfile/parser.go
+++ b/internal/aptfile/parser.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 )
 
@@ -17,12 +18,18 @@ const (
 	EntryTypeKey EntryType = "key"
 )
 
+// validKeyNameRe matches valid key alias names used in "key <url> as <name>".
+// Names must start with an alphanumeric character and may contain alphanumeric
+// characters, dots, hyphens, or underscores.
+var validKeyNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+
 // Entry represents a single parsed directive from an Aptfile, including
 // the directive type, its argument value, the source line number, and
 // the original unparsed line text.
 type Entry struct {
 	Type     EntryType
 	Value    string
+	Name     string // optional alias for key directives: "key <url> as <name>"
 	LineNum  int
 	Original string
 }
@@ -92,9 +99,27 @@ func parseLine(line string, lineNum int, original string) (Entry, error) {
 		return Entry{}, fmt.Errorf("unknown directive: %s", directive)
 	}
 
+	// For key directives, parse optional "as <name>" suffix.
+	// Example: key https://example.com/key.gpg as mykey
+	var name string
+	if entryType == EntryTypeKey {
+		if idx := strings.LastIndex(value, " as "); idx >= 0 {
+			potentialName := strings.TrimSpace(value[idx+4:])
+			// Only treat as a name if it's a single word (no spaces) and non-empty.
+			if potentialName != "" && !strings.Contains(potentialName, " ") {
+				if !validKeyNameRe.MatchString(potentialName) {
+					return Entry{}, fmt.Errorf("invalid key name %q: must start with alphanumeric and contain only alphanumeric, dot, hyphen, or underscore", potentialName)
+				}
+				name = potentialName
+				value = strings.TrimSpace(value[:idx])
+			}
+		}
+	}
+
 	return Entry{
 		Type:     entryType,
 		Value:    value,
+		Name:     name,
 		LineNum:  lineNum,
 		Original: original,
 	}, nil

--- a/internal/aptfile/parser_test.go
+++ b/internal/aptfile/parser_test.go
@@ -372,6 +372,105 @@ func TestEntry(t *testing.T) {
 	}
 }
 
+func TestKeyNameParsing(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		wantVal  string
+		wantName string
+		wantErr  bool
+	}{
+		{
+			name:     "key without name",
+			line:     "key https://example.com/key.gpg",
+			wantVal:  "https://example.com/key.gpg",
+			wantName: "",
+		},
+		{
+			name:     "key with simple name",
+			line:     "key https://example.com/key.gpg as mykey",
+			wantVal:  "https://example.com/key.gpg",
+			wantName: "mykey",
+		},
+		{
+			name:     "key with hyphenated name",
+			line:     "key https://repo.charm.sh/apt/gpg.key as charm-key",
+			wantVal:  "https://repo.charm.sh/apt/gpg.key",
+			wantName: "charm-key",
+		},
+		{
+			name:     "key with dot in name",
+			line:     "key https://example.com/key.gpg as my.key",
+			wantVal:  "https://example.com/key.gpg",
+			wantName: "my.key",
+		},
+		{
+			name:     "key with underscore in name",
+			line:     "key https://example.com/key.gpg as my_key",
+			wantVal:  "https://example.com/key.gpg",
+			wantName: "my_key",
+		},
+		{
+			name:    "key with invalid name (starts with hyphen)",
+			line:    "key https://example.com/key.gpg as -invalid",
+			wantErr: true,
+		},
+		{
+			name:    "key with invalid name (contains space - parsed as two words, last wins)",
+			line:    "key https://example.com/key.gpg as invalid!name",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry, err := parseLine(tt.line, 1, tt.line)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseLine() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if entry.Value != tt.wantVal {
+				t.Errorf("Entry.Value = %q, want %q", entry.Value, tt.wantVal)
+			}
+			if entry.Name != tt.wantName {
+				t.Errorf("Entry.Name = %q, want %q", entry.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestKeyNameInFullAptfile(t *testing.T) {
+	content := `key https://repo.charm.sh/apt/gpg.key as charm
+deb "[signed-by=charm] https://repo.charm.sh/apt/ * *"
+key https://example.com/key.gpg
+deb "https://example.com/apt/ stable main"
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "Aptfile")
+	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := Parse(tmpFile)
+	if err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(entries))
+	}
+	if entries[0].Type != EntryTypeKey || entries[0].Value != "https://repo.charm.sh/apt/gpg.key" || entries[0].Name != "charm" {
+		t.Errorf("entry[0]: got type=%s value=%q name=%q", entries[0].Type, entries[0].Value, entries[0].Name)
+	}
+	if entries[1].Type != EntryTypeDeb || entries[1].Value != "[signed-by=charm] https://repo.charm.sh/apt/ * *" {
+		t.Errorf("entry[1]: got type=%s value=%q", entries[1].Type, entries[1].Value)
+	}
+	if entries[2].Type != EntryTypeKey || entries[2].Name != "" {
+		t.Errorf("entry[2]: expected key with no name, got name=%q", entries[2].Name)
+	}
+}
+
 func TestParseScannerError(t *testing.T) {
 	t.Run("line too long triggers scanner error", func(t *testing.T) {
 		tmpDir := t.TempDir()

--- a/internal/commands/dump.go
+++ b/internal/commands/dump.go
@@ -13,12 +13,15 @@ var dumpCmd = &cobra.Command{
 	Use:   "dump",
 	Short: "Generate an Aptfile from the current system state",
 	Long: `Dump generates an Aptfile by listing all manually installed packages
-and optionally custom PPAs and repositories from the system.
+and custom PPAs and repositories from the system.
 
-Limitation: Repositories that use Signed-By (GPG keys) are emitted as deb lines
-only. The corresponding key directive is not included, since dump reads from
-.sources files which store key paths, not URLs. When installing from a dumped
-Aptfile, you may need to add key directives manually for custom repositories.`,
+For repositories managed by apt-bundle that use Signed-By (GPG keys), the
+corresponding key directive is emitted automatically when the key was downloaded
+by apt-bundle (which stores the original URL alongside the key file).
+
+For repositories added by other tools or older versions of apt-bundle, the key
+directive may not be available; in that case only the deb line is emitted and
+you may need to add the key directive manually.`,
 	RunE: runDump,
 }
 
@@ -53,6 +56,9 @@ func runDump(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "# --- Repositories ---")
 		for _, e := range sources {
+			if e.KeyURL != "" {
+				fmt.Fprintln(w, "key", e.KeyURL)
+			}
 			fmt.Fprintln(w, e.AptfileLine)
 		}
 	}

--- a/internal/commands/dump_test.go
+++ b/internal/commands/dump_test.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"bytes"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -55,6 +57,75 @@ func TestRunDump(t *testing.T) {
 		vimIdx := strings.Index(out, "apt vim")
 		if curlIdx > gitIdx || gitIdx > vimIdx {
 			t.Errorf("packages should be sorted: curl < git < vim, got positions curl=%d git=%d vim=%d", curlIdx, gitIdx, vimIdx)
+		}
+	})
+
+	t.Run("emits key directive before deb line when KeyURL is known", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		sourcesDir := filepath.Join(tmpDir, "sources.list.d")
+		sourcesList := filepath.Join(tmpDir, "sources.list")
+		if err := os.MkdirAll(sourcesDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write a key file and its companion URL file
+		keyPath := filepath.Join(tmpDir, "keyrings", "apt-bundle-test.gpg")
+		if err := os.MkdirAll(filepath.Dir(keyPath), 0755); err != nil {
+			t.Fatal(err)
+		}
+		const keyURL = "https://repo.charm.sh/apt/gpg.key"
+		if err := os.WriteFile(keyPath, []byte("fake key"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".url", []byte(keyURL), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write a .sources file that references the key
+		sourcesContent := "Types: deb\nURIs: https://repo.charm.sh/apt\nSuites: *\nComponents: *\nSigned-By: " + keyPath + "\n"
+		if err := os.WriteFile(filepath.Join(sourcesDir, "charm.sources"), []byte(sourcesContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		mock := testutil.NewMockExecutor()
+		mock.OutputFunc = func(name string, args ...string) ([]byte, error) {
+			if name == "apt-mark" && len(args) > 0 && args[0] == "showmanual" {
+				return []byte(""), nil
+			}
+			return nil, errors.New("unexpected command")
+		}
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			Executor: mock,
+		}
+		defer func() { mgr = origMgr }()
+
+		// Override the sources paths used by ListCustomSources
+		origSourcesListPath := apt.SourcesListPath
+		apt.SourcesListPath = sourcesList
+		defer func() { apt.SourcesListPath = origSourcesListPath }()
+		origSourcesDir := apt.SourcesDir
+		apt.SourcesDir = sourcesDir
+		defer func() { apt.SourcesDir = origSourcesDir }()
+
+		var buf bytes.Buffer
+		dumpCmd.SetOut(&buf)
+		defer dumpCmd.SetOut(nil)
+
+		err := runDump(dumpCmd, []string{})
+		if err != nil {
+			t.Fatalf("runDump: %v", err)
+		}
+
+		out := buf.String()
+		if !strings.Contains(out, "key "+keyURL) {
+			t.Errorf("output should contain 'key %s', got:\n%s", keyURL, out)
+		}
+		// key line must appear before deb line
+		keyIdx := strings.Index(out, "key "+keyURL)
+		debIdx := strings.Index(out, "deb ")
+		if keyIdx > debIdx {
+			t.Errorf("key line should appear before deb line in output")
 		}
 	})
 

--- a/internal/commands/install.go
+++ b/internal/commands/install.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/apt-bundle/apt-bundle/internal/apt"
 	"github.com/apt-bundle/apt-bundle/internal/aptfile"
@@ -68,6 +69,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 
 	var pendingKeyPath string
 	var reposAdded bool
+	namedKeys := make(map[string]string) // name → key path (from "key <url> as <name>")
 
 	for _, entry := range entries {
 		switch entry.Type {
@@ -78,6 +80,9 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			}
 			pendingKeyPath = keyPath
 			state.AddKey(keyPath)
+			if entry.Name != "" {
+				namedKeys[entry.Name] = keyPath
+			}
 
 		case aptfile.EntryTypePPA:
 			if err := mgr.AddPPA(entry.Value); err != nil {
@@ -87,7 +92,25 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			reposAdded = true
 
 		case aptfile.EntryTypeDeb:
-			sourcePath, err := mgr.AddDebRepository(entry.Value, pendingKeyPath)
+			cleanedLine, signedByValue, err := extractDebSignedBy(entry.Value)
+			if err != nil {
+				return fmt.Errorf("failed to parse deb line: %w", err)
+			}
+			keyPath := pendingKeyPath
+			if signedByValue != "" {
+				if strings.HasPrefix(signedByValue, "/") {
+					// Direct absolute path reference
+					keyPath = signedByValue
+				} else {
+					// Named key reference — must have been declared with "key ... as <name>"
+					resolved, ok := namedKeys[signedByValue]
+					if !ok {
+						return fmt.Errorf("deb line references key %q via signed-by=, but no 'key <url> as %s' was defined before this line", signedByValue, signedByValue)
+					}
+					keyPath = resolved
+				}
+			}
+			sourcePath, err := mgr.AddDebRepository(cleanedLine, keyPath)
 			if err != nil {
 				return fmt.Errorf("failed to add repository: %w", err)
 			}
@@ -157,6 +180,49 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// extractDebSignedBy extracts and removes a "signed-by=<value>" option from the
+// bracket options of a deb line. It returns the cleaned line (with signed-by removed)
+// and the extracted value. Other bracket options (e.g. arch=amd64) are preserved.
+// If no signed-by option is present, the original line and an empty string are returned.
+//
+// Examples:
+//
+//	"[signed-by=charm] https://..."      → "https://...", "charm"
+//	"[arch=amd64 signed-by=charm] https://..." → "[arch=amd64] https://...", "charm"
+//	"https://..."                         → "https://...", ""
+func extractDebSignedBy(line string) (cleanedLine string, signedByValue string, err error) {
+	if !strings.HasPrefix(line, "[") {
+		return line, "", nil
+	}
+	closeBracket := strings.Index(line, "]")
+	if closeBracket < 0 {
+		return line, "", nil
+	}
+
+	bracketContent := line[1:closeBracket]
+	rest := line[closeBracket+1:]
+
+	var otherOptions []string
+	for _, opt := range strings.Fields(bracketContent) {
+		if strings.HasPrefix(opt, "signed-by=") {
+			signedByValue = strings.TrimPrefix(opt, "signed-by=")
+		} else {
+			otherOptions = append(otherOptions, opt)
+		}
+	}
+
+	if signedByValue == "" {
+		return line, "", nil
+	}
+
+	if len(otherOptions) == 0 {
+		cleanedLine = strings.TrimSpace(rest)
+	} else {
+		cleanedLine = "[" + strings.Join(otherOptions, " ") + "]" + rest
+	}
+	return cleanedLine, signedByValue, nil
+}
+
 func writeLockFileFromPackages(packages []string) error {
 	// The skipped-packages list is intentionally dropped here; unlike the
 	// standalone lock command, install --lock does not warn about uninstalled packages.
@@ -191,7 +257,10 @@ func runInstallDryRun(entries []aptfile.Entry) error {
 				wouldAddRepos = append(wouldAddRepos, line)
 			}
 		case aptfile.EntryTypeDeb:
-			line := "deb " + entry.Value
+			// Strip signed-by=<name> from bracket options before comparing, since
+			// ListCustomSources does not include signed-by in its AptfileLine output.
+			cleanedValue, _, _ := extractDebSignedBy(entry.Value)
+			line := "deb " + cleanedValue
 			if !sourceLines[line] {
 				wouldAddRepos = append(wouldAddRepos, line)
 			}

--- a/internal/commands/install_test.go
+++ b/internal/commands/install_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/apt-bundle/apt-bundle/internal/apt"
@@ -521,6 +522,108 @@ func TestRunInstallWithMock(t *testing.T) {
 
 		if checkCalls == 0 {
 			t.Error("Expected IsPackageInstalled to be called")
+		}
+	})
+}
+
+func TestExtractDebSignedBy(t *testing.T) {
+	tests := []struct {
+		name            string
+		line            string
+		wantCleanedLine string
+		wantSignedBy    string
+	}{
+		{
+			name:            "no bracket options",
+			line:            "https://repo.charm.sh/apt/ * *",
+			wantCleanedLine: "https://repo.charm.sh/apt/ * *",
+			wantSignedBy:    "",
+		},
+		{
+			name:            "signed-by only in bracket",
+			line:            "[signed-by=charm] https://repo.charm.sh/apt/ * *",
+			wantCleanedLine: "https://repo.charm.sh/apt/ * *",
+			wantSignedBy:    "charm",
+		},
+		{
+			name:            "signed-by with arch in bracket",
+			line:            "[arch=amd64 signed-by=charm] https://download.docker.com/linux/ubuntu focal stable",
+			wantCleanedLine: "[arch=amd64] https://download.docker.com/linux/ubuntu focal stable",
+			wantSignedBy:    "charm",
+		},
+		{
+			name:            "signed-by first then arch",
+			line:            "[signed-by=charm arch=amd64] https://example.com/apt focal main",
+			wantCleanedLine: "[arch=amd64] https://example.com/apt focal main",
+			wantSignedBy:    "charm",
+		},
+		{
+			name:            "arch only in bracket",
+			line:            "[arch=amd64] https://example.com/apt focal main",
+			wantCleanedLine: "[arch=amd64] https://example.com/apt focal main",
+			wantSignedBy:    "",
+		},
+		{
+			name:            "signed-by with absolute path",
+			line:            "[signed-by=/etc/apt/keyrings/foo.gpg] https://example.com/apt focal main",
+			wantCleanedLine: "https://example.com/apt focal main",
+			wantSignedBy:    "/etc/apt/keyrings/foo.gpg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLine, gotSignedBy, err := extractDebSignedBy(tt.line)
+			if err != nil {
+				t.Fatalf("extractDebSignedBy() error: %v", err)
+			}
+			if gotLine != tt.wantCleanedLine {
+				t.Errorf("cleanedLine = %q, want %q", gotLine, tt.wantCleanedLine)
+			}
+			if gotSignedBy != tt.wantSignedBy {
+				t.Errorf("signedByValue = %q, want %q", gotSignedBy, tt.wantSignedBy)
+			}
+		})
+	}
+}
+
+func TestRunInstallNamedKey(t *testing.T) {
+	t.Run("unknown named key returns error", func(t *testing.T) {
+		cleanup := setupMockRoot()
+		defer cleanup()
+
+		tmpDir := t.TempDir()
+		mock := testutil.NewMockExecutor()
+		origMgr := mgr
+		mgr = &apt.AptManager{
+			Executor:      mock,
+			KeyringDir:    filepath.Join(tmpDir, "keyrings"),
+			SourcesDir:    filepath.Join(tmpDir, "sources"),
+			SourcesPrefix: "apt-bundle-",
+			StatePath:     func() string { return filepath.Join(tmpDir, "state.json") },
+		}
+		defer func() { mgr = origMgr }()
+
+		noUpdate = true
+		defer func() { noUpdate = false }()
+
+		tmpFile := filepath.Join(tmpDir, "Aptfile")
+		// deb line references "charm" but no key with that name was defined
+		content := "deb \"[signed-by=charm] https://repo.charm.sh/apt/ * *\"\n"
+		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		origPath := aptfilePath
+		aptfilePath = tmpFile
+		defer func() { aptfilePath = origPath }()
+
+		err := runInstall(installCmd, []string{})
+		if err == nil {
+			t.Error("expected error for unknown key name, got nil")
+		}
+		if err != nil && !strings.Contains(err.Error(), "charm") {
+			t.Errorf("error should mention key name 'charm', got: %v", err)
 		}
 	})
 }

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -12,6 +12,7 @@ var (
 	aptfilePath string
 	noUpdate    bool
 	version     = "dev"
+	commit      = "unknown"
 )
 
 // mgr is the AptManager used by all commands.
@@ -26,7 +27,6 @@ var rootCmd = &cobra.Command{
 	Long: `apt-bundle provides a simple, declarative, and shareable way to manage
 apt packages and repositories on Debian-based systems, inspired by Homebrew's
 brew bundle.`,
-	Version: version,
 }
 
 func Execute() error {
@@ -34,6 +34,7 @@ func Execute() error {
 }
 
 func init() {
+	rootCmd.Version = version + " (" + commit + ")"
 	rootCmd.PersistentFlags().StringVarP(&aptfilePath, "file", "f", "Aptfile", "Path to Aptfile")
 	rootCmd.PersistentFlags().BoolVar(&noUpdate, "no-update", false, "Skip updating package lists before installing")
 }

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -38,6 +39,13 @@ func TestRootCmd(t *testing.T) {
 
 		if rootCmd.Version == "" {
 			t.Error("rootCmd.Version should not be empty")
+		}
+	})
+
+	t.Run("version flag format", func(t *testing.T) {
+		v := rootCmd.Version
+		if !strings.Contains(v, " (") || !strings.HasSuffix(v, ")") {
+			t.Errorf("rootCmd.Version %q does not match expected format '<version> (<commit>)'", v)
 		}
 	})
 
@@ -89,6 +97,20 @@ func TestCheckRoot(t *testing.T) {
 			if err == nil {
 				t.Error("checkRoot() should return error when not running as root")
 			}
+		}
+	})
+}
+
+func TestVersionVariables(t *testing.T) {
+	t.Run("version defaults to dev", func(t *testing.T) {
+		if version != "dev" {
+			t.Errorf("version = %q, want %q", version, "dev")
+		}
+	})
+
+	t.Run("commit defaults to unknown", func(t *testing.T) {
+		if commit != "unknown" {
+			t.Errorf("commit = %q, want %q", commit, "unknown")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Implements the feature requested in #67: explicit `signed-by=` key association and dump round-trip support.

### What's new

**Aptfile syntax** — named key aliases:
```aptfile
key https://repo.charm.sh/apt/gpg.key as charm
deb "[signed-by=charm] https://repo.charm.sh/apt/ * *"
```

The `signed-by=<name>` bracket option explicitly associates a named key with a deb repository, independent of line order. A direct path (`signed-by=/etc/apt/keyrings/foo.gpg`) also works.

**Backward-compatible** — the existing positional mechanism (`key` line immediately before `deb` line) is unchanged.

**Dump round-trip** — `apt-bundle dump` now emits `key <url>` before `deb` lines for repositories whose key was downloaded by apt-bundle:
```
key https://repo.charm.sh/apt/gpg.key
deb https://repo.charm.sh/apt/ * *
```

This closes the limitation noted in the dump help text and the README. For keys not managed by apt-bundle (installed manually or by other tools), only the deb line is emitted as before.

### Implementation details

- **`key ... as <name>`**: parser recognises optional `as <name>` suffix on key directives; name must be alphanumeric/hyphen/underscore/dot.
- **Named key map**: install command maintains a `name → path` map; `signed-by=<name>` in deb bracket options is resolved and stripped before the `.sources` file is written.
- **Companion URL file**: `AddGPGKey` writes `<keyfile>.gpg.url` alongside each downloaded key; `RemoveGPGKey` removes it. `parseDEB822Stanza` reads this file to populate `SourceEntry.KeyURL`.
- **Dry-run fix**: strips `signed-by=<name>` before comparing against installed sources so idempotency works correctly.
- **Bug fix**: `gpg --dearmor` was failing because `os.CreateTemp` pre-creates the output file and gpg refuses to overwrite it; fixed by removing the empty temp file before invoking gpg.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New unit tests: parser (`TestKeyNameParsing`, `TestKeyNameInFullAptfile`), `extractDebSignedBy`, named key error case, companion URL file write/remove, `parseDEB822Stanza` with Signed-By, dump with KeyURL
- [x] Integration test on host: installed charm repo with named key, verified URL file written, verified dump emits `key` directive, verified dry-run shows nothing-to-do